### PR TITLE
Feature/idcom 1021 did self upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,9 +1100,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
+checksum = "716d3d89f35ac6a34fd0eed635395f4c3b76fa889338a4632e5231a8684216bd"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -2040,7 +2040,7 @@ dependencies = [
 [[package]]
 name = "sol-did"
 version = "0.2.0"
-source = "git+https://github.com/identity-com/sol-did#e28badd889719068c0156d5974998f8c2d568ef1"
+source = "git+https://github.com/identity-com/sol-did?rev=b51bf82af14e3b5917d231a255f5fdb390b96eda#b51bf82af14e3b5917d231a255f5fdb390b96eda"
 dependencies = [
  "borsh",
  "num-derive",

--- a/cli/src/commands/airdrop.ts
+++ b/cli/src/commands/airdrop.ts
@@ -28,7 +28,7 @@ export default class Airdrop extends Command {
     const { flags, args } = this.parse(Airdrop);
 
     const config = new Config(flags.config);
-    const cryptid = await build(config);
+    const cryptid = build(config);
 
     await airdrop(cryptid, config, args.amount);
   }

--- a/cli/src/commands/balance.ts
+++ b/cli/src/commands/balance.ts
@@ -20,7 +20,7 @@ export default class Balance extends Command {
     const { flags } = this.parse(Balance);
 
     const config = new Config(flags.config);
-    const cryptid = await build(config);
+    const cryptid = build(config);
 
     const address = await cryptid.address();
     const cryptidBalance = await balance(cryptid, config);

--- a/cli/src/commands/config.ts
+++ b/cli/src/commands/config.ts
@@ -31,7 +31,7 @@ export default class Config extends Command {
     const { args, flags } = this.parse(Config);
 
     const service = new ConfigService(flags.config);
-    const cryptid = await build(service);
+    const cryptid = build(service);
 
     const address = await cryptid.address();
 

--- a/cli/src/commands/key.ts
+++ b/cli/src/commands/key.ts
@@ -67,7 +67,7 @@ export default class Key extends Command {
     const { args, flags } = this.parse(Key);
 
     const config = new Config(flags.config);
-    const cryptid = await build(config);
+    const cryptid = build(config);
 
     switch (args.subcommand) {
       case Subcommand.SHOW:

--- a/cli/src/commands/transfer.ts
+++ b/cli/src/commands/transfer.ts
@@ -32,7 +32,7 @@ export default class Transfer extends Command {
     const { flags } = this.parse(Transfer);
 
     const config = new Config(flags.config);
-    const cryptid = await build(config);
+    const cryptid = build(config);
     const address = await cryptid.address();
 
     const { blockhash: recentBlockhash } =

--- a/cli/src/service/cryptid/index.ts
+++ b/cli/src/service/cryptid/index.ts
@@ -1,7 +1,7 @@
 import { Cryptid, build as buildCryptid } from "@identity.com/cryptid";
 import { Config } from "../config";
 
-export const build = (config: Config): Promise<Cryptid> =>
+export const build = (config: Config): Cryptid =>
   buildCryptid(config.did, config.keypair, {
     connection: config.connection,
   });

--- a/client/src/api/builder.ts
+++ b/client/src/api/builder.ts
@@ -5,11 +5,11 @@ import { normalizeSigner } from '../lib/util';
 import { SimpleCryptid } from './simpleCryptid';
 
 export class Builder {
-  static async build(
+  static build(
     did: string,
     signer: Keypair | Signer,
     options: CryptidOptions
-  ): Promise<Cryptid> {
+  ): Cryptid {
     return new SimpleCryptid(did, normalizeSigner(signer), options);
   }
 }

--- a/client/src/lib/solana/instructions/directExecute.ts
+++ b/client/src/lib/solana/instructions/directExecute.ts
@@ -5,7 +5,7 @@ import {
   TransactionInstruction,
 } from '@solana/web3.js';
 import { Signer } from '../../../types/crypto';
-import {deriveDefaultDOAFromKey, deriveDOASigner} from '../util';
+import { deriveDefaultDOAFromKey, deriveDOASigner } from '../util';
 import { CryptidInstruction } from './instruction';
 import { DOA_PROGRAM_ID, SOL_DID_PROGRAM_ID } from '../../constants';
 import { any, find, propEq } from 'ramda';
@@ -15,18 +15,18 @@ import { AssignablePublicKey } from '../model/AssignablePublicKey';
 
 export const create = async (
   unsignedTransaction: Transaction,
-  didKey: PublicKey,
+  didPDAKey: PublicKey,
   signers: Signer[],
   doa?: PublicKey
 ): Promise<TransactionInstruction> => {
-  const sendingDoa = doa || (await deriveDefaultDOAFromKey(didKey));
+  const sendingDoa = doa || (await deriveDefaultDOAFromKey(didPDAKey));
 
   const doa_signer_key = await deriveDOASigner(sendingDoa).then(
-    signer => signer[0]
+    (signer) => signer[0]
   );
 
   const instruction_accounts: AccountMeta[] = [];
-  unsignedTransaction.instructions.forEach(instruction => {
+  unsignedTransaction.instructions.forEach((instruction) => {
     if (!any(propEq('pubkey', instruction.programId))(instruction_accounts)) {
       instruction_accounts.push({
         pubkey: instruction.programId,
@@ -35,7 +35,7 @@ export const create = async (
       });
     }
 
-    instruction.keys.forEach(account => {
+    instruction.keys.forEach((account) => {
       const found: AccountMeta | undefined = find<AccountMeta>(
         propEq('pubkey', account.pubkey)
       )(instruction_accounts);
@@ -56,12 +56,12 @@ export const create = async (
   const keys: AccountMeta[] = [
     { pubkey: sendingDoa, isSigner: false, isWritable: false },
     {
-      pubkey: didKey,
+      pubkey: didPDAKey,
       isSigner: false,
       isWritable: false,
     },
     { pubkey: SOL_DID_PROGRAM_ID, isSigner: false, isWritable: false },
-    ...signers.map(signer => ({
+    ...signers.map((signer) => ({
       pubkey: signer.publicKey,
       isSigner: true,
       isWritable: false,
@@ -70,7 +70,7 @@ export const create = async (
   ];
 
   const instructions: InstructionData[] = unsignedTransaction.instructions.map(
-    instruction =>
+    (instruction) =>
       new InstructionData({
         program_id: AssignablePublicKey.fromPublicKey(instruction.programId),
         accounts: instruction.keys.map(TransactionAccountMeta.fromAccountMeta),

--- a/client/src/lib/solana/transactions/did/addKey.ts
+++ b/client/src/lib/solana/transactions/did/addKey.ts
@@ -1,9 +1,13 @@
 import { Connection, PublicKey, Transaction } from '@solana/web3.js';
-import {makeVerificationMethod} from "../../../did";
-import {createUpdateInstruction, resolve} from "@identity.com/sol-did-client";
-import {Signer} from "../../../../types/crypto";
-import {createTransaction, registerInstructionIfNeeded} from "../util";
-import {notNil} from "../../../util";
+import { makeVerificationMethod } from '../../../did';
+import {
+  createUpdateInstruction,
+  DecentralizedIdentifier,
+  resolve,
+} from '@identity.com/sol-did-client';
+import { Signer } from '../../../../types/crypto';
+import { createTransaction, registerInstructionIfNeeded } from '../util';
+import { notNil } from '../../../util';
 
 /**
  * Creates a transaction that adds a key to a DID.
@@ -17,37 +21,42 @@ export const addKey = async (
   payer: PublicKey,
   newKey: PublicKey,
   alias: string,
-  signers: Signer[],
+  signers: Signer[]
 ): Promise<Transaction> => {
   // resolve the existing document so that any existing capability invocation keys can be included in the registered version
   // if this is missed, registering with a new key removes the old key, which we don't want in this case.
   const existingDocument = await resolve(did);
-  const verificationMethod = makeVerificationMethod(did, newKey, alias)
+  const verificationMethod = makeVerificationMethod(did, newKey, alias);
   const document = {
     verificationMethod: [verificationMethod],
-    capabilityInvocation: [...(existingDocument.capabilityInvocation || []), verificationMethod.id],
+    capabilityInvocation: [
+      ...(existingDocument.capabilityInvocation || []),
+      verificationMethod.id,
+    ],
   };
 
   // if the did is not registered, register it with the new key
   // if the did is registered, this will return null
-  const registerInstruction = await registerInstructionIfNeeded(connection, did, payer, document)
+  const registerInstruction = await registerInstructionIfNeeded(
+    connection,
+    did,
+    payer,
+    document
+  );
 
   let instructions = [registerInstruction];
 
   // if the did is registered, update it
   if (!registerInstruction) {
     const updateInstruction = await createUpdateInstruction({
-      authority: signers[0].publicKey,
+      authority: await DecentralizedIdentifier.parse(
+        did
+      ).authorityPubkey.toPublicKey(),
       identifier: did,
       document,
     });
     instructions = [updateInstruction];
   }
 
-  return createTransaction(
-    connection,
-    notNil(instructions),
-    payer,
-    signers
-  );
+  return createTransaction(connection, notNil(instructions), payer, signers);
 };

--- a/client/src/lib/solana/transactions/directExecute.ts
+++ b/client/src/lib/solana/transactions/directExecute.ts
@@ -1,8 +1,8 @@
 import { Connection, PublicKey, Transaction } from '@solana/web3.js';
 import { create } from '../instructions/directExecute';
 import { Signer } from '../../../types/crypto';
-import {createTransaction, didIsRegistered} from "./util";
-import {DecentralizedIdentifier} from "@identity.com/sol-did-client";
+import { createTransaction } from './util';
+import { DecentralizedIdentifier } from '@identity.com/sol-did-client';
 
 /**
  * Creates a Direct_Execute transaction, that signs and sends a transaction from a DID
@@ -15,14 +15,12 @@ export const directExecute = async (
   signers: Signer[],
   doa?: PublicKey
 ): Promise<Transaction> => {
-  // TODO @brett https://civicteam.slack.com/archives/C01361EBHU1/p1632382952242200
-  const isRegistered = await didIsRegistered(connection, did);
-  const parsedDID = DecentralizedIdentifier.parse(did)
-  const didKey = isRegistered ? await parsedDID.pdaSolanaPubkey() : parsedDID.authorityPubkey.toPublicKey()
+  const parsedDID = DecentralizedIdentifier.parse(did);
+  const didPDAKey = await parsedDID.pdaSolanaPubkey();
 
   const directExecuteInstruction = await create(
     unsignedTransaction,
-    didKey,
+    didPDAKey,
     signers,
     doa
   );

--- a/client/src/lib/solana/transactions/util.ts
+++ b/client/src/lib/solana/transactions/util.ts
@@ -1,8 +1,16 @@
-import {Connection, PublicKey, Transaction, TransactionInstruction} from "@solana/web3.js";
-import {Signer} from "../../../types/crypto";
-import {createRegisterInstruction, DecentralizedIdentifier} from "@identity.com/sol-did-client";
-import {DEFAULT_DID_DOCUMENT_SIZE, SOL_DID_PROGRAM_ID} from "../../constants";
-import {DIDDocument} from "did-resolver";
+import {
+  Connection,
+  PublicKey,
+  Transaction,
+  TransactionInstruction,
+} from '@solana/web3.js';
+import { Signer } from '../../../types/crypto';
+import {
+  createRegisterInstruction,
+  DecentralizedIdentifier,
+} from '@identity.com/sol-did-client';
+import { DEFAULT_DID_DOCUMENT_SIZE, SOL_DID_PROGRAM_ID } from '../../constants';
+import { DIDDocument } from 'did-resolver';
 
 /**
  * Create a new empty transaction, initialised with a fee payer and a recent transaction hash
@@ -10,12 +18,15 @@ import {DIDDocument} from "did-resolver";
  * @param payer The fee payer for the transaction
  * @param signers A sorted list of signers. The first one will be the fee payer for the transaction
  */
-const makeEmptyTransaction = async (connection: Connection, payer: PublicKey) => {
+const makeEmptyTransaction = async (
+  connection: Connection,
+  payer: PublicKey
+) => {
   const recentBlockhashPromise = connection.getRecentBlockhash();
   const { blockhash: recentBlockhash } = await recentBlockhashPromise;
 
   return new Transaction({ recentBlockhash, feePayer: payer });
-}
+};
 
 /**
  * Creates and signs a transaction from an array of instructions
@@ -24,7 +35,7 @@ export const createTransaction = async (
   connection: Connection,
   instructions: TransactionInstruction[],
   payer: PublicKey,
-  signers: Signer[],
+  signers: Signer[]
 ): Promise<Transaction> => {
   let transaction = await makeEmptyTransaction(connection, payer);
 
@@ -36,15 +47,23 @@ export const createTransaction = async (
   return transaction;
 };
 
-const registerInstruction = async (payer: PublicKey, authority: PublicKey, document?: Partial<DIDDocument>, size: number = DEFAULT_DID_DOCUMENT_SIZE) =>
+const registerInstruction = async (
+  payer: PublicKey,
+  authority: PublicKey,
+  document?: Partial<DIDDocument>,
+  size: number = DEFAULT_DID_DOCUMENT_SIZE
+) =>
   createRegisterInstruction({
     payer,
     authority,
     size,
-    document
-  })
+    document,
+  });
 
-export const didIsRegistered = async (connection: Connection, did: string):Promise<boolean> => {
+export const didIsRegistered = async (
+  connection: Connection,
+  did: string
+): Promise<boolean> => {
   const decentralizedIdentifier = DecentralizedIdentifier.parse(did);
   const pda = await decentralizedIdentifier.pdaSolanaPubkey();
 
@@ -54,15 +73,28 @@ export const didIsRegistered = async (connection: Connection, did: string):Promi
 
   if (account.owner.equals(SOL_DID_PROGRAM_ID)) return true;
 
-  throw new Error(`Invalid DID ${did}, the derived account ${pda} is registered to another program`);
-}
+  throw new Error(
+    `Invalid DID ${did}, the derived account ${pda} is registered to another program`
+  );
+};
 
-export const registerInstructionIfNeeded = async (connection: Connection, did: string, payer: PublicKey, document?: Partial<DIDDocument>, size?: number): Promise<TransactionInstruction|null> => {
+export const registerInstructionIfNeeded = async (
+  connection: Connection,
+  did: string,
+  payer: PublicKey,
+  document?: Partial<DIDDocument>,
+  size?: number
+): Promise<TransactionInstruction | null> => {
   const isRegistered = await didIsRegistered(connection, did);
 
   if (isRegistered) return null;
 
   const decentralizedIdentifier = DecentralizedIdentifier.parse(did);
-  const [ instruction ] = await registerInstruction(payer, decentralizedIdentifier.authorityPubkey.toPublicKey(), document, size);
+  const [instruction] = await registerInstruction(
+    payer,
+    decentralizedIdentifier.authorityPubkey.toPublicKey(),
+    document,
+    size
+  );
   return instruction;
 };

--- a/client/src/lib/solana/util.ts
+++ b/client/src/lib/solana/util.ts
@@ -1,7 +1,14 @@
 import { PublicKey } from '@solana/web3.js';
-import {DEFAULT_CLUSTER, DOA_PROGRAM_ID, SOL_DID_PROGRAM_ID} from '../constants';
-import {ExtendedCluster} from "../../types/solana";
-import {ClusterType, DecentralizedIdentifier} from "@identity.com/sol-did-client";
+import {
+  DEFAULT_CLUSTER,
+  DOA_PROGRAM_ID,
+  SOL_DID_PROGRAM_ID,
+} from '../constants';
+import { ExtendedCluster } from '../../types/solana';
+import {
+  ClusterType,
+  DecentralizedIdentifier,
+} from '@identity.com/sol-did-client';
 
 const DOA_SEED = 'cryptid_doa';
 const DOA_SIGNER_SEED = 'doa_signer';
@@ -15,31 +22,28 @@ export const publicKeyToDid = (
     ClusterType.parse(cluster || DEFAULT_CLUSTER)
   ).toString();
 
-export const didToPublicKey = (did: string): PublicKey =>
-  DecentralizedIdentifier.parse(did).authorityPubkey.toPublicKey();
-
 /**
- *
  * Given a key representing either a DID or a DID's PDA
- * (TODO @brett https://civicteam.slack.com/archives/C01361EBHU1/p1632382952242200),
  * derive the default DOA
- * @param didKey
+ * @param didPDAKey the key to the didPDA
  */
-export const deriveDefaultDOAFromKey = async (didKey: PublicKey):Promise<PublicKey> => {
+export const deriveDefaultDOAFromKey = async (
+  didPDAKey: PublicKey
+): Promise<PublicKey> => {
   const publicKeyNonce = await PublicKey.findProgramAddress(
     [
       SOL_DID_PROGRAM_ID.toBuffer(),
-      didKey.toBuffer(),
+      didPDAKey.toBuffer(),
       Buffer.from(DOA_SEED, 'utf8'),
     ],
     DOA_PROGRAM_ID
   );
   return publicKeyNonce[0];
-}
+};
 
 export const deriveDefaultDOA = async (did: string): Promise<PublicKey> => {
-  const didKey = await DecentralizedIdentifier.parse(did).authorityPubkey.toPublicKey();
-  return deriveDefaultDOAFromKey(didKey)
+  const didKey = await DecentralizedIdentifier.parse(did).pdaSolanaPubkey();
+  return deriveDefaultDOAFromKey(didKey);
 };
 
 export const deriveDOASigner = async (

--- a/client/test/e2e/did.test.ts
+++ b/client/test/e2e/did.test.ts
@@ -110,9 +110,7 @@ describe('DID operations', function () {
         await balances.recordBefore();
       });
 
-      // Fails due to https://civicteam.slack.com/archives/C01361EBHU1/p1632384991242400?thread_ts=1632382952.242200&cid=C01361EBHU1
-      // TODO @brett
-      it.skip('should add a new key', async () => {
+      it('should add a new key', async () => {
         await cryptid.addKey(newKey, newKeyAlias);
 
         await balances.recordAfter();

--- a/client/test/e2e/transfer.test.ts
+++ b/client/test/e2e/transfer.test.ts
@@ -4,6 +4,7 @@ import { build, Cryptid } from '../../src';
 import { Connection, Keypair, PublicKey } from '@solana/web3.js';
 import {
   airdrop,
+  Balances,
   createTransferTransaction,
   sendAndConfirmCryptidTransaction,
 } from '../utils/solana';
@@ -12,7 +13,7 @@ import { publicKeyToDid } from '../../src/lib/solana/util';
 const { expect } = chai;
 
 // needs to be less than AIRDROP_LAMPORTS
-const lamportsToTransfer = 50_000;
+const lamportsToTransfer = 20_000;
 
 describe('transfers', function () {
   this.timeout(20_000);
@@ -24,6 +25,7 @@ describe('transfers', function () {
   let recipient: PublicKey;
 
   let cryptid: Cryptid;
+  let balances: Balances;
 
   before(async () => {
     connection = new Connection('http://localhost:8899', 'confirmed');
@@ -46,6 +48,14 @@ describe('transfers', function () {
   });
 
   context('a simple cryptid', () => {
+    beforeEach(async () => {
+      balances = await new Balances(connection).register(
+        doaSigner,
+        key.publicKey,
+        recipient
+      );
+    });
+
     it('should sign a transaction from a DID', async () => {
       const cryptid = await build(did, key, { connection });
 
@@ -56,50 +66,20 @@ describe('transfers', function () {
         lamportsToTransfer
       );
 
-      // record balances before sending
-      const signerPreBalance = await connection.getBalance(key.publicKey);
-      const cryptidPreBalance = await connection.getBalance(doaSigner);
-
       const [cryptidTx] = await cryptid.sign(tx);
       await sendAndConfirmCryptidTransaction(connection, cryptidTx);
 
-      // record balances after sending
-      const signerPostBalance = await connection.getBalance(key.publicKey);
-      const cryptidPostBalance = await connection.getBalance(doaSigner);
-      const recipientPostBalance = await connection.getBalance(recipient);
-
-      console.log({
-        signer: {
-          signerPreBalance,
-          signerPostBalance,
-        },
-        cryptid: {
-          cryptidPreBalance,
-          cryptidPostBalance,
-        },
-        recipient: {
-          recipientPostBalance,
-        },
-      });
+      await balances.recordAfter();
 
       // assert balances are correct
-      expect(cryptidPreBalance - cryptidPostBalance).to.equal(
-        lamportsToTransfer
-      ); // the amount transferred
-      expect(signerPreBalance - signerPostBalance).to.equal(5000); // fees only
+      expect(balances.for(doaSigner)).to.equal(-lamportsToTransfer); // the amount transferred
+      expect(balances.for(key.publicKey)).to.equal(-5000); // fees only
 
       // skip for now as it is consistently returning 2,439 lamports too few
-      // expect(recipientPostBalance).to.equal(lamportsToTransfer);
+      // expect(balances.for(recipient).to.equal(lamportsToTransfer);
     });
 
-    // Fails due to https://civicteam.slack.com/archives/C01361EBHU1/p1632384991242400?thread_ts=1632382952.242200&cid=C01361EBHU1
-    // TODO @brett
-    it.skip('should sign a transaction from a DID with a second key', async () => {
-      // record balance at the start
-      const cryptidPreBalance = await connection.getBalance(doaSigner);
-
-      // the initial key held by device 1
-      const device1Key = key;
+    it('should sign a transaction from a DID with a second key', async () => {
       // the cryptid client for device 1 that will add the new key
       const cryptidForDevice1 = cryptid;
 
@@ -107,11 +87,8 @@ describe('transfers', function () {
       const device2Key = Keypair.generate();
       const alias = 'device2';
 
-      // airdrop enough funds into device 1 key ot cover rent
-      // TODO figure out how to allow the cryptid account to pay for this
-      await airdrop(connection, device1Key.publicKey, 50_000_000);
-      // airdrop to the new key to cover fees only
-      await airdrop(connection, device2Key.publicKey, 100_000);
+      // airdrop to device2 key to cover fees for the transfer only
+      await airdrop(connection, device2Key.publicKey, 10_000);
 
       // add the new key and create a cryptid client for device 2
       await cryptidForDevice1.addKey(device2Key.publicKey, alias);
@@ -120,10 +97,6 @@ describe('transfers', function () {
         waitForConfirmation: true,
       });
 
-      console.log(`DOA Signer ${doaSigner}`);
-      console.log(`DID ${did}`);
-      console.log(`device2Key ${device2Key.publicKey}`);
-
       // create a transfer and sign with cryptid for device 2
       const tx = await createTransferTransaction(
         connection,
@@ -131,16 +104,16 @@ describe('transfers', function () {
         recipient,
         lamportsToTransfer
       );
+
+      await balances.recordBefore(); // reset balances to exclude rent costs for adding device2
+
       const [cryptidTx] = await cryptidForDevice2.sign(tx);
       await sendAndConfirmCryptidTransaction(connection, cryptidTx);
 
-      // record balances after sending
-      const cryptidPostBalance = await connection.getBalance(doaSigner);
+      await balances.recordAfter();
 
       // assert balances are correct
-      expect(cryptidPreBalance - cryptidPostBalance).to.equal(
-        lamportsToTransfer
-      ); // the amount transferred
+      expect(balances.for(doaSigner)).to.equal(-lamportsToTransfer); // the amount transferred
     });
   });
 });

--- a/programs/cryptid_signer/Cargo.toml
+++ b/programs/cryptid_signer/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib", "lib"]
 solana_generator = { path = "../../solana_generator" }
 borsh = "0.9.1"
 bitflags = "1.3.2"
-sol-did = { git = "https://github.com/identity-com/sol-did", features = ["no-entrypoint"] }
+sol-did = { git = "https://github.com/identity-com/sol-did", rev = "b51bf82af14e3b5917d231a255f5fdb390b96eda", features = ["no-entrypoint"] }
 
 [dev-dependencies]
 solana-sdk = "1.7.12"


### PR DESCRIPTION
Enables cryptid accounts to pay rent for their own upgrade aka anchoring on-chain.

By default, addKey will use directExecute(), and the cryptid account (aka doa signer) will pay rent to register the DID.
Disable this by setting rentPayer: 'SIGNER_PAYS' in the cryptid options.