### PR TITLE
IDCOM-1122 Allow Larger Allocations

### DIFF
--- a/client/src/lib/solana/instructions/directExecute.ts
+++ b/client/src/lib/solana/instructions/directExecute.ts
@@ -1,6 +1,8 @@
 import {
   AccountMeta,
   PublicKey,
+  SystemInstruction,
+  SystemProgram,
   Transaction,
   TransactionInstruction,
 } from '@solana/web3.js';
@@ -17,31 +19,69 @@ export const create = async (
   signers: [Signer, AccountMeta[]][],
   doa?: PublicKey,
   debug = false
-): Promise<TransactionInstruction> => {
-  const sendingDoa: PublicKey =
+): Promise<TransactionInstruction[]> => {
+  const cryptidAccount: PublicKey =
     doa || (await deriveDefaultDOAFromKey(didPDAKey));
 
-  const doa_signer_key: PublicKey = await deriveDOASigner(sendingDoa).then(
-    (signer) => signer[0]
+  const cryptidSignerKey: PublicKey = await deriveDOASigner(
+    cryptidAccount
+  ).then((signer) => signer[0]);
+
+  console.log(unsignedTransaction);
+
+  if (signers.length < 1) {
+    throw new Error('Not enough signers for directExecute');
+  }
+
+  const instructionsLists = convertInstructions(
+    unsignedTransaction.instructions,
+    cryptidSignerKey,
+    signers[0][0].publicKey
   );
 
+  return instructionsLists.flatMap((instructionsList) => {
+    if (instructionsList[1]) {
+      return [
+        convertToDirectExecute(
+          instructionsList[0],
+          didPDAKey,
+          signers,
+          cryptidAccount,
+          cryptidSignerKey,
+          debug
+        ),
+      ];
+    } else {
+      return instructionsList[0];
+    }
+  });
+};
+
+function convertToDirectExecute(
+  instructions: TransactionInstruction[],
+  didPDAKey: PublicKey,
+  signers: [Signer, AccountMeta[]][],
+  cryptidAccount: PublicKey,
+  cryptidSignerKey: PublicKey,
+  debug: boolean
+): TransactionInstruction {
   const instruction_accounts: AccountMeta[] = [];
-  unsignedTransaction.instructions.forEach((instruction) => {
+  instructions.forEach((instruction) => {
     // Add the program that will be called as not a signer and not writable
     addMetaUnique(
       instruction_accounts,
       { pubkey: instruction.programId, isSigner: false, isWritable: false },
-      doa_signer_key
+      cryptidSignerKey
     );
 
     // Add each instruction's key, order doesn't matter to the program
     instruction.keys.forEach((account) =>
-      addMetaUnique(instruction_accounts, account, doa_signer_key)
+      addMetaUnique(instruction_accounts, account, cryptidSignerKey)
     );
   });
 
   const keys: AccountMeta[] = [
-    { pubkey: sendingDoa, isSigner: false, isWritable: false },
+    { pubkey: cryptidAccount, isSigner: false, isWritable: false },
     { pubkey: didPDAKey, isSigner: false, isWritable: false },
     { pubkey: SOL_DID_PROGRAM_ID, isSigner: false, isWritable: false },
     ...signers.flatMap(([signer, extras]) => [
@@ -51,7 +91,7 @@ export const create = async (
     ...instruction_accounts,
   ];
 
-  const instructions: InstructionData[] = unsignedTransaction.instructions.map(
+  const directExecuteInstructions: InstructionData[] = instructions.map(
     (instruction) =>
       InstructionData.fromTransactionInstruction(
         instruction,
@@ -62,7 +102,7 @@ export const create = async (
   const data: Buffer = CryptidInstruction.directExecute(
     // Map into number of extra accounts array
     signers.map((extra_accounts) => extra_accounts[1].length),
-    instructions,
+    directExecuteInstructions,
     debug
   ).encode();
 
@@ -71,7 +111,142 @@ export const create = async (
     programId: DOA_PROGRAM_ID,
     data,
   });
-};
+}
+
+/**
+ * Returns an array of arrays of transaction instructions with a boolean telling if they should be run as a direct execute
+ * @param instructions The instructions to convert.
+ * @param signerKey The cryptid signer key
+ * @param firstSigner The first signer in the list of signers
+ */
+// TODO: Make this actually look for instruction dependencies rather than just assuming creates and allocates all go before others, some may rely on instructions that are not create/allocate
+function convertInstructions(
+  instructions: TransactionInstruction[],
+  signerKey: PublicKey,
+  firstSigner: PublicKey
+): [TransactionInstruction[], boolean][] {
+  const out: ReturnType<typeof convertInstructions> = [
+    [[], true],
+    [[], false],
+    [[], true],
+  ];
+  const beforeInstructions = out[0][0];
+  const middleInstructions = out[1][0];
+  const afterInstructions = out[2][0];
+
+  for (const instruction of instructions) {
+    const convert = convertInstruction(instruction, signerKey, firstSigner);
+    beforeInstructions.push(...convert.before);
+    middleInstructions.push(...convert.middle);
+    afterInstructions.push(...convert.after);
+  }
+
+  return out;
+}
+
+// Returns before, middle, after wh
+function convertInstruction(
+  instruction: TransactionInstruction,
+  signerKey: PublicKey,
+  firstSigner: PublicKey
+): {
+  before: TransactionInstruction[];
+  middle: TransactionInstruction[];
+  after: TransactionInstruction[];
+} {
+  // Must handle case where trying to allocate account with greater than 10240 bytes of space
+  if (instruction.programId.equals(SystemProgram.programId)) {
+    const type = SystemInstruction.decodeInstructionType(instruction);
+    if (type === 'Create') {
+      const create = SystemInstruction.decodeCreateAccount(instruction);
+      if (create.space > 10240) {
+        // If large enough space required do allocation outside direct execute
+        if (create.fromPubkey.equals(signerKey)) {
+          // If funder is our signer we transfer to the signing key and then use those funds for the creation
+          return {
+            before: [
+              SystemProgram.transfer({
+                fromPubkey: signerKey,
+                lamports: create.lamports,
+                toPubkey: firstSigner,
+              }),
+            ],
+            middle: [
+              SystemProgram.createAccount({
+                ...create,
+                fromPubkey: firstSigner,
+              }),
+            ],
+            after: [],
+          };
+        } else {
+          // If not our key run it outside the direct execute
+          return {
+            before: [],
+            middle: [instruction],
+            after: [],
+          };
+        }
+      }
+    } else if (type === 'CreateWithSeed') {
+      // If large enough space required do allocation outside direct execute
+      const create = SystemInstruction.decodeCreateWithSeed(instruction);
+      if (create.space > 10240) {
+        if (create.fromPubkey.equals(signerKey)) {
+          // If funder is our signer we transfer to the signing key and then use those funds for the creation
+          return {
+            before: [
+              SystemProgram.transfer({
+                fromPubkey: signerKey,
+                lamports: create.lamports,
+                toPubkey: firstSigner,
+              }),
+            ],
+            middle: [
+              SystemProgram.createAccountWithSeed({
+                ...create,
+                fromPubkey: firstSigner,
+              }),
+            ],
+            after: [],
+          };
+        } else {
+          // If not our key run it outside the direct execute
+          return {
+            before: [],
+            middle: [instruction],
+            after: [],
+          };
+        }
+      }
+    } else if (type === 'Allocate' || type === 'AllocateWithSeed') {
+      // Allocate doesn't transfer funds so just run it outside unless it's small enough or our signer is involved
+      let allocateSize: number;
+      let allocateAccount: PublicKey;
+      if (type === 'Allocate') {
+        const allocate = SystemInstruction.decodeAllocate(instruction);
+        allocateSize = allocate.space;
+        allocateAccount = allocate.accountPubkey;
+      } else {
+        const allocate = SystemInstruction.decodeAllocateWithSeed(instruction);
+        allocateSize = allocate.space;
+        allocateAccount = allocate.accountPubkey;
+      }
+      if (allocateSize > 10240 && !allocateAccount.equals(signerKey)) {
+        return {
+          before: [],
+          middle: [instruction],
+          after: [],
+        };
+      }
+    }
+  }
+  return {
+    before: [],
+    middle: [],
+    after: [instruction],
+  };
+}
 
 const addMetaUnique = (
   array: AccountMeta[],

--- a/client/src/lib/solana/transactions/directExecute.ts
+++ b/client/src/lib/solana/transactions/directExecute.ts
@@ -44,7 +44,7 @@ export const directExecute = async (
   );
   return createTransaction(
     unsignedTransaction.recentBlockhash,
-    [directExecuteInstruction],
+    directExecuteInstruction,
     payer,
     signersNormalized.map(([signer]) => signer)
   );

--- a/client/test/unit/lib/solana/transactions/directExecute.test.ts
+++ b/client/test/unit/lib/solana/transactions/directExecute.test.ts
@@ -85,7 +85,7 @@ describe('transactions/directExecute', () => {
     const transaction = new Transaction();
     transaction.add(instruction);
     const didPDAKey = Keypair.generate().publicKey;
-    const direct_execute = await create(transaction, didPDAKey, []);
+    const direct_execute = (await create(transaction, didPDAKey, []))[0];
     console.log(
       direct_execute.keys.map((key) => ({
         ...key,


### PR DESCRIPTION
Allow for larger allocations by executing them seperately and obtaining the funds from the signer if nessisary.