### PR TITLE
Feature/idcom 1398  swap program id on dev stage

### DIFF
--- a/.github/workflows/programs-cryptid-signer.yml
+++ b/.github/workflows/programs-cryptid-signer.yml
@@ -133,7 +133,7 @@ jobs:
 
   program-dev-deploy:
     name: Deploy dev cryptid on-chain program, built on Solana ${{ matrix.solana }}, Rust ${{ matrix.rust }}, and ${{ matrix.os }}
-    if: github.ref == 'refs/heads/develop' && github.event == 'push'
+    if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
     needs: [program-lint, program-unit-test, program-integration-test]
     env:
       SOLANA_PROGRAM_ID: tcrjc6mfci8bQLmXPfrVw9fJm9Y5tr268tByjSQmSe9

--- a/.github/workflows/programs-cryptid-signer.yml
+++ b/.github/workflows/programs-cryptid-signer.yml
@@ -2,7 +2,7 @@ name: Programs-Cryptid-Signer
 on:
   push:
     paths:
-      - 'programs-cryptid-signer'
+      - 'programs/cryptid_signer/**'
   pull_request:
 jobs:
   program-lint:

--- a/cli/test/commands/address.test.ts
+++ b/cli/test/commands/address.test.ts
@@ -6,7 +6,7 @@ describe("address", () => {
     .command(["address"])
     .it("shows the address", (ctx) => {
       expect(ctx.stdout).to.contain(
-        "3BMioQBfrQcxTFRSv4Sg51jdLau2pVbHxYJ5U24Z8Yfw"
+        "EUxLMi2Km3s9wxygRbAR3KKRBoQQZV1p8HAqyu3Dok8k"
       );
     });
 });

--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,7 @@
     "analyze": "size-limit --why",
     "test-e2e": "start-server-and-test start-validator http://localhost:8899/health test-e2e-pattern",
     "test-e2e-pattern": "mocha test/e2e",
-    "start-validator": "solana-test-validator --bpf-program CFE6uDuLK7Hd9HVQqWkXU3nTmdZUm5KCEtFcEfbSTZLy ../target/deploy/cryptid_signer.so --bpf-program idDa4XeCjVwKcprVAo812coUQbovSZ4kDGJf2sPaBnM ../programs/cryptid_signer/tests/fixtures/sol_did_1.0.0.so --reset"
+    "start-validator": "solana-test-validator --bpf-program crypt1GWL27FYSg7gEfJVzbc8KzEcTToFNmaXi9ropg ../target/deploy/cryptid_signer.so --bpf-program idDa4XeCjVwKcprVAo812coUQbovSZ4kDGJf2sPaBnM ../programs/cryptid_signer/tests/fixtures/sol_did_1.0.0.so --reset"
   },
   "nyc": {
     "extends": "@istanbuljs/nyc-config-typescript",

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -8,7 +8,7 @@ export const SOL_DID_PROGRAM_ID = new PublicKey(
 export const CRYPTID_PROGRAM_ID =
   process.env.STAGE === 'dev'
     ? new PublicKey('tcrjc6mfci8bQLmXPfrVw9fJm9Y5tr268tByjSQmSe9')
-    : new PublicKey('CFE6uDuLK7Hd9HVQqWkXU3nTmdZUm5KCEtFcEfbSTZLy');
+    : new PublicKey('crypt1GWL27FYSg7gEfJVzbc8KzEcTToFNmaXi9ropg');
 
 export const DEFAULT_CLUSTER: ExtendedCluster = 'mainnet-beta';
 

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -5,9 +5,11 @@ export const SOL_DID_PROGRAM_ID = new PublicKey(
   'idDa4XeCjVwKcprVAo812coUQbovSZ4kDGJf2sPaBnM'
 );
 
-export const DOA_PROGRAM_ID = new PublicKey(
-  'CFE6uDuLK7Hd9HVQqWkXU3nTmdZUm5KCEtFcEfbSTZLy'
-);
+export const DOA_PROGRAM_ID =
+  process.env.STAGE === 'dev'
+    ? new PublicKey('tcrjc6mfci8bQLmXPfrVw9fJm9Y5tr268tByjSQmSe9')
+    : new PublicKey('CFE6uDuLK7Hd9HVQqWkXU3nTmdZUm5KCEtFcEfbSTZLy');
+
 export const DEFAULT_CLUSTER: ExtendedCluster = 'mainnet-beta';
 
 export const DEFAULT_DID_DOCUMENT_SIZE = 1_500;

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -5,7 +5,7 @@ export const SOL_DID_PROGRAM_ID = new PublicKey(
   'idDa4XeCjVwKcprVAo812coUQbovSZ4kDGJf2sPaBnM'
 );
 
-export const DOA_PROGRAM_ID =
+export const CRYPTID_PROGRAM_ID =
   process.env.STAGE === 'dev'
     ? new PublicKey('tcrjc6mfci8bQLmXPfrVw9fJm9Y5tr268tByjSQmSe9')
     : new PublicKey('CFE6uDuLK7Hd9HVQqWkXU3nTmdZUm5KCEtFcEfbSTZLy');

--- a/client/src/lib/solana/instructions/directExecute.ts
+++ b/client/src/lib/solana/instructions/directExecute.ts
@@ -9,7 +9,7 @@ import {
 import { Signer } from '../../../types/crypto';
 import { deriveDefaultDOAFromKey, deriveDOASigner } from '../util';
 import { CryptidInstruction } from './instruction';
-import { DOA_PROGRAM_ID, SOL_DID_PROGRAM_ID } from '../../constants';
+import { CRYPTID_PROGRAM_ID, SOL_DID_PROGRAM_ID } from '../../constants';
 import { find, propEq } from 'ramda';
 import { InstructionData } from '../model/InstructionData';
 
@@ -111,7 +111,7 @@ function convertToDirectExecute(
 
   return new TransactionInstruction({
     keys,
-    programId: DOA_PROGRAM_ID,
+    programId: CRYPTID_PROGRAM_ID,
     data,
   });
 }

--- a/client/src/lib/solana/util.ts
+++ b/client/src/lib/solana/util.ts
@@ -1,7 +1,7 @@
 import { PublicKey } from '@solana/web3.js';
 import {
   DEFAULT_CLUSTER,
-  DOA_PROGRAM_ID,
+  CRYPTID_PROGRAM_ID,
   SOL_DID_PROGRAM_ID,
 } from '../constants';
 import { ExtendedCluster } from '../../types/solana';
@@ -36,7 +36,7 @@ export const deriveDefaultDOAFromKey = async (
       SOL_DID_PROGRAM_ID.toBuffer(),
       didPDAKey.toBuffer(),
     ],
-    DOA_PROGRAM_ID
+    CRYPTID_PROGRAM_ID
   );
   return publicKeyNonce[0];
 };
@@ -57,6 +57,6 @@ export const deriveDOASigner = async (
 ): Promise<[PublicKey, number]> => {
   return await PublicKey.findProgramAddress(
     [Buffer.from(DOA_SIGNER_SEED, 'utf8'), doa.toBuffer()],
-    DOA_PROGRAM_ID
+    CRYPTID_PROGRAM_ID
   );
 };

--- a/client/test/unit/api/simpleCryptid.test.ts
+++ b/client/test/unit/api/simpleCryptid.test.ts
@@ -183,7 +183,7 @@ describe('SimpleCryptid', () => {
 
       const address = await cryptid.address();
       expect(address.toBase58()).to.equal(
-        'DA2m96dgMW9vC6BMFTCo8HvMPibq1SB8iYY7z7veedG4'
+        '4Uk7SRqmZH2avVaTE63FjVrJPS7whve3muPEgDv9FMCy'
       );
     });
   });

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "cargo build",
     "test-programs": "cargo build-bpf && start-server-and-test start-validator http://localhost:8899/health test-programs:inner",
     "test-programs:inner": "cargo test && cargo test-bpf && yarn workspace programs test",
-    "start-validator": "solana-test-validator --reset --bpf-program CFE6uDuLK7Hd9HVQqWkXU3nTmdZUm5KCEtFcEfbSTZLy ./target/deploy/cryptid_signer.so --bpf-program idDa4XeCjVwKcprVAo812coUQbovSZ4kDGJf2sPaBnM ./programs/cryptid_signer/tests/fixtures/sol_did_1.0.0.so"
+    "start-validator": "solana-test-validator --reset --bpf-program crypt1GWL27FYSg7gEfJVzbc8KzEcTToFNmaXi9ropg ./target/deploy/cryptid_signer.so --bpf-program idDa4XeCjVwKcprVAo812coUQbovSZ4kDGJf2sPaBnM ./programs/cryptid_signer/tests/fixtures/sol_did_1.0.0.so"
   },
   "devDependencies": {
     "start-server-and-test": "^1.14.0"

--- a/wallet/craco.config.js
+++ b/wallet/craco.config.js
@@ -1,4 +1,6 @@
 // craco.config.js
+const { DefinePlugin } = require('webpack');
+
 module.exports = {
   style: {
     postcss: {
@@ -7,5 +9,13 @@ module.exports = {
         require('autoprefixer'),
       ],
     },
+  },
+  webpack: {
+    plugins: [
+      // include process.env.STAGE provided during build at runtime
+      new DefinePlugin({
+        'process.env.STAGE': JSON.stringify(process.env.STAGE ?? 'prod')
+      })
+    ]
   },
 }


### PR DESCRIPTION
* Use a different program id on the dev stage
* Renamed DOA_PROGRAM_ID to CRYPTID_PROGRAM_ID
* Updated wallet build to include STAGE env variable at build time (updated webpack to include `process.env.STAGE` environemnt variable)
* Updated to use new `crypt...` program id