### PR TITLE
Feature/idcom 1371  direct execute instruction splitting

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -49,7 +49,7 @@ jobs:
       matrix:
         node: ['16.x']
         os: [ubuntu-latest]
-        solana: ['v1.7.12']
+        solana: ['v1.8.14']
         rust: ['1.55']
 
     steps:

--- a/.github/workflows/programs-cryptid-signer.yml
+++ b/.github/workflows/programs-cryptid-signer.yml
@@ -85,7 +85,7 @@ jobs:
     strategy:
       matrix:
         rust: ['1.55']
-        solana: ['v1.7.12']
+        solana: ['v1.8.14']
         os: [ubuntu-latest]
 
     steps:

--- a/client/src/lib/solana/instructions/directExecute.ts
+++ b/client/src/lib/solana/instructions/directExecute.ts
@@ -147,13 +147,13 @@ function convertInstruction(
           const createInstruction =
             type === 'Create'
               ? SystemProgram.createAccount({
-                ...(create as CreateAccountParams),
-                fromPubkey: firstSigner,
-              })
+                  ...(create as CreateAccountParams),
+                  fromPubkey: firstSigner,
+                })
               : SystemProgram.createAccountWithSeed({
-                ...(create as CreateAccountWithSeedParams),
-                fromPubkey: firstSigner,
-              });
+                  ...(create as CreateAccountWithSeedParams),
+                  fromPubkey: firstSigner,
+                });
 
           return [
             convertToDirectExecute(
@@ -172,12 +172,12 @@ function convertInstruction(
         }
       }
     } else if (type === 'Allocate' || type === 'AllocateWithSeed') {
-      // Allocate doesn't transfer funds so just run it outside unless it's small enough or our signer is involved
       const allocate =
         type === 'Allocate'
           ? SystemInstruction.decodeAllocate(instruction)
           : SystemInstruction.decodeAllocateWithSeed(instruction);
 
+      // Allocate doesn't transfer funds so just run it outside unless it's small enough or our signer is involved
       if (
         allocate.space > MAX_PROGRAM_SIZE &&
         !allocate.accountPubkey.equals(cryptidSignerKey)


### PR DESCRIPTION
Split instructions to reset compute limits...

Given the following case:
```
Transfer #A
Create Large Account #1 (> 10240 in size)
Create Small Account (<= 10240 in size)
Create Large Account #2 (> 10240 in size)
Transfer #B
```

It was previsously generating the following transaction:
```
Wrapped("Transfer for Create Large Account #1", "Transfer for Create Large Account #2")
Create Large Account #1
Create Large Account #2
Wrapped(Transfer #A, Create Small Account, Transfer #B)
```

This has been changed to:
```
Wrapped(Transfer #A)
Wrapped(Transfer for Create Large Account #1)
Create Large Account #1
Wrapped(Create Small Account)
Wrapped(Transfer for Create Large Account #2)
Create Large Account #2
Wrapped(Transfer #B)
```

--

The main change, is where it was previsouly creating 3 lists (before, middle and after) - wrapping before and after in a single transaction, it now creates a single list adding instructions as needed (wrapped or not)

--

Updated Solana for CI to v1.8.14