### PR TITLE
Fix 'cannot read properties' error on CLI airdrop command

### DIFF
--- a/cli/src/commands/airdrop.ts
+++ b/cli/src/commands/airdrop.ts
@@ -20,6 +20,11 @@ export default class Airdrop extends Base {
   async run(): Promise<void> {
     const { args } = await this.parse(Airdrop);
 
-    await airdrop(this.cryptid, this.cryptidConfig, args.amount, this.log.bind(this));
+    await airdrop(
+      this.cryptid,
+      this.cryptidConfig,
+      args.amount,
+      this.log.bind(this)
+    );
   }
 }

--- a/cli/src/commands/airdrop.ts
+++ b/cli/src/commands/airdrop.ts
@@ -20,6 +20,6 @@ export default class Airdrop extends Base {
   async run(): Promise<void> {
     const { args } = await this.parse(Airdrop);
 
-    await airdrop(this.cryptid, this.cryptidConfig, args.amount, this.log);
+    await airdrop(this.cryptid, this.cryptidConfig, args.amount, this.log.bind(this));
   }
 }


### PR DESCRIPTION
Fix 'cannot read properties' error on CLI airdrop command, by binding 'this' to the log function passed into the airdrop service.