### PR TITLE
Update address.test.ts

### DIFF
--- a/cli/test/commands/address.test.ts
+++ b/cli/test/commands/address.test.ts
@@ -6,7 +6,7 @@ describe("address", () => {
     .command(["address"])
     .it("shows the address", (ctx) => {
       expect(ctx.stdout).to.contain(
-        "EUxLMi2Km3s9wxygRbAR3KKRBoQQZV1p8HAqyu3Dok8k"
+        "didso1Dpqpm4CsiCjzP766BGY89CAdD6ZBL68cRhFPc"
       );
     });
 });


### PR DESCRIPTION
With the change of the did:sol client, the derived address did not match this current test.