### PR TITLE
Middleware: A simple time-delay middleware

### DIFF
--- a/cryptid_anchor/Anchor.toml
+++ b/cryptid_anchor/Anchor.toml
@@ -1,15 +1,18 @@
 [workspace]
 members = [
     "programs/cryptid_anchor",
-    "programs/middleware/check_recipient"
+    "programs/middleware/check_recipient",
+    "programs/middleware/time_delay"
 ]
 
 [features]
 seeds = false
 skip-lint = false
+
 [programs.localnet]
 cryptid_anchor = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
 check_recipient = "midcHDoZsxvMmNtUr8howe8MWFrJeHHPbAyJF1nHvyf"
+time_delay = "midttN2h6G2CBvt1kpnwUsFXM6Gv7gratVwuo2XhSNk"
 
 [registry]
 url = "https://api.apr.dev"

--- a/cryptid_anchor/Cargo.lock
+++ b/cryptid_anchor/Cargo.lock
@@ -387,6 +387,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "check_pass"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "cryptid_anchor",
+ "solana-gateway",
+]
+
+[[package]]
 name = "check_recipient"
 version = "0.1.0"
 dependencies = [
@@ -487,7 +496,7 @@ dependencies = [
  "anchor-lang",
  "bitflags",
  "num-traits",
- "sol-did",
+ "sol-did 3.0.0",
 ]
 
 [[package]]
@@ -1129,6 +1138,19 @@ checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "sol-did"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2546d424d6898908c205d99d3af07ad42e2e8aec8f0d459235dc0bd4e9866fe"
+dependencies = [
+ "borsh",
+ "num-derive",
+ "num-traits",
+ "solana-program",
+ "thiserror",
+]
+
+[[package]]
+name = "sol-did"
 version = "3.0.0"
 source = "git+https://github.com/identity-com/sol-did?rev=b0a32154aa7d2d42666865a90356e9c50616dca2#b0a32154aa7d2d42666865a90356e9c50616dca2"
 dependencies = [
@@ -1174,6 +1196,21 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn",
+]
+
+[[package]]
+name = "solana-gateway"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "243daaf437dff89891d520c3e9be7b4a6940c30a1bda2ac094e621046f303eda"
+dependencies = [
+ "bitflags",
+ "borsh",
+ "num-derive",
+ "num-traits",
+ "sol-did 0.2.0",
+ "solana-program",
+ "thiserror",
 ]
 
 [[package]]
@@ -1272,6 +1309,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time_delay"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "cryptid_anchor",
 ]
 
 [[package]]

--- a/cryptid_anchor/programs/middleware/check_recipient/src/lib.rs
+++ b/cryptid_anchor/programs/middleware/check_recipient/src/lib.rs
@@ -67,7 +67,7 @@ pub struct Create<'info> {
     #[account(
         init,
         payer = authority,
-        space = 8 + 32 + 32 + 8 + 8,
+        space = 8 + CheckRecipient::MAX_SIZE,
         seeds = [CheckRecipient::SEED_PREFIX, authority.key().as_ref(), nonce.to_le_bytes().as_ref()],
         bump,
     )]
@@ -124,6 +124,8 @@ pub struct CheckRecipient {
 }
 impl CheckRecipient {
     pub const SEED_PREFIX: &'static [u8] = b"check_recipient";
+
+    pub const MAX_SIZE: usize = 32 + 32 + 1 + 1;
 }
 
 #[error_code]

--- a/cryptid_anchor/programs/middleware/time_delay/Cargo.toml
+++ b/cryptid_anchor/programs/middleware/time_delay/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "time_delay"
+version = "0.1.0"
+description = "Created with Anchor"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "time_delay"
+
+[features]
+no-entrypoint = []
+no-idl = []
+no-log-ix-name = []
+cpi = ["no-entrypoint"]
+default = []
+
+[dependencies]
+anchor-lang = "0.25.0"
+cryptid_anchor = { path = "../../cryptid_anchor", features = ["no-entrypoint", "cpi"] }

--- a/cryptid_anchor/programs/middleware/time_delay/Xargo.toml
+++ b/cryptid_anchor/programs/middleware/time_delay/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/cryptid_anchor/programs/middleware/time_delay/src/lib.rs
+++ b/cryptid_anchor/programs/middleware/time_delay/src/lib.rs
@@ -1,0 +1,169 @@
+// This is a simple permissionless safety mechanism that can be added to a cryptid account.
+//
+// It protects, for example, against attacks that trick a user into signing a transaction to move funds out of their cryptid account. The transaction can be created, but the attacker must trick a user a second time, some time later, to execute the transaction.
+//
+// This is an example of a middleware that has its own transaction-level state, indicating the time at which the tx was initially created. The flow for a transaction using this middleware is therefore:
+//
+// Cryptid.propose -> create the tx
+// Middleware.registerTransaction -> register the creation time with the middleware
+// <<wait>>
+// Middleware.execute -> approves the transaction if enough time has passed
+// Cryptid.execute -> executes the transaction
+
+extern crate core;
+
+use anchor_lang::prelude::*;
+use anchor_lang::solana_program::clock::UnixTimestamp;
+use cryptid_anchor::cpi::accounts::ApproveExecution;
+use cryptid_anchor::program::CryptidAnchor;
+use cryptid_anchor::state::transaction_account::TransactionAccount;
+
+declare_id!("midttN2h6G2CBvt1kpnwUsFXM6Gv7gratVwuo2XhSNk");
+
+#[program]
+pub mod time_delay {
+    use super::*;
+
+    pub fn create(ctx: Context<Create>, seconds: i64, bump: u8) -> Result<()> {
+        ctx.accounts.middleware_account.authority = *ctx.accounts.authority.key;
+        ctx.accounts.middleware_account.seconds = seconds;
+        ctx.accounts.middleware_account.bump = bump;
+        Ok(())
+    }
+
+    pub fn register_transaction(ctx: Context<RegisterTransaction>) -> Result<()> {
+        ctx.accounts.transaction_create_time.time = Clock::get()?.unix_timestamp;
+
+        Ok(())
+    }
+
+    pub fn execute_middleware(ctx: Context<ExecuteMiddleware>, _transaction_create_time_bump: u8) -> Result<()> {
+        let transaction_account = &ctx.accounts.transaction_account;
+        let transaction_create_time = &ctx.accounts.transaction_create_time;
+        let middleware_account = &ctx.accounts.middleware_account;
+
+        let current_time = Clock::get()?.unix_timestamp;
+        let earliest_allowable_time = transaction_create_time.time + middleware_account.seconds;
+
+        require_gte!(current_time, earliest_allowable_time, ErrorCode::TooSoon);
+
+        ExecuteMiddleware::approve(ctx)
+    }
+}
+
+#[derive(Accounts)]
+#[instruction(
+/// The number of seconds that must pass before the transaction can be executed
+seconds: i64,
+/// The bump seed for the middleware signer
+bump: u8
+)]
+pub struct Create<'info> {
+    #[account(
+        init,
+        payer = authority,
+        space = 8 + TimeDelay::MAX_SIZE,
+        seeds = [TimeDelay::SEED_PREFIX, authority.key().as_ref(), &seconds.to_le_bytes()],
+        bump,
+    )]
+    pub middleware_account: Account<'info, TimeDelay>,
+    #[account(mut)]
+    pub authority: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct RegisterTransaction<'info> {
+    #[account()]
+    pub middleware_account: Account<'info, TimeDelay>,
+    #[account()]
+    pub transaction_account: Account<'info, TransactionAccount>,
+    #[account(mut)]
+    pub authority: Signer<'info>,
+    #[account(
+        init,
+        payer = authority,
+        space = 8 + TransactionCreationTime::MAX_SIZE,
+        seeds = [TransactionCreationTime::SEED_PREFIX, transaction_account.key().as_ref()],
+        bump,
+    )]
+    pub transaction_create_time: Account<'info, TransactionCreationTime>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+#[instruction(
+/// The bump seed used to generate the transaction_create_time account
+transaction_create_time_bump: u8
+)]
+pub struct ExecuteMiddleware<'info> {
+    #[account()]
+    pub middleware_account: Account<'info, TimeDelay>,
+    #[account(mut)]
+    pub transaction_account: Account<'info, TransactionAccount>,
+    /// CHECK: Rent destination account does not need to satisfy the any constraints.
+    #[account(mut)]
+    pub destination: UncheckedAccount<'info>,
+    /// The account containing the transaction create time
+    /// the current time must be after the one registered here
+    #[account(
+        mut,
+        close = destination,
+        seeds = [TransactionCreationTime::SEED_PREFIX, transaction_account.key().as_ref()],
+        bump = transaction_create_time_bump,
+    )]
+    pub transaction_create_time: Account<'info, TransactionCreationTime>,
+    pub cryptid_program: Program<'info, CryptidAnchor>,
+}
+impl<'info> ExecuteMiddleware<'info> {
+    // TODO abstract this into shared?
+    pub fn approve(ctx: Context<ExecuteMiddleware>) -> Result<()> {
+        let cpi_program = ctx.accounts.cryptid_program.to_account_info();
+        let cpi_accounts = ApproveExecution {
+            middleware_account: ctx.accounts.middleware_account.to_account_info(),
+            transaction_account: ctx.accounts.transaction_account.to_account_info(),
+        };
+        // define seeds inline here rather than extract to a function
+        // in order to avoid having to convert Vec<Vec<u8>> to &[&[u8]]
+        let authority_key = ctx.accounts.middleware_account.authority.key();
+        let seconds = ctx.accounts.middleware_account.seconds.to_le_bytes();
+        let bump = ctx.accounts.middleware_account.bump.to_le_bytes();
+        let seeds = &[
+            TimeDelay::SEED_PREFIX,
+            authority_key.as_ref(),
+            seconds.as_ref(),
+            bump.as_ref(),
+        ][..];
+        let signer = &[seeds][..];
+        let cpi_ctx = CpiContext::new_with_signer(cpi_program, cpi_accounts, signer);
+        cryptid_anchor::cpi::approve_execution(cpi_ctx)
+    }
+}
+
+#[account()]
+pub struct TimeDelay {
+    pub authority: Pubkey,
+    pub seconds: i64, // i64 to match the UnixTimestamp type
+    pub bump: u8,
+}
+impl TimeDelay {
+    pub const SEED_PREFIX: &'static [u8] = b"time_delay";
+
+    pub const MAX_SIZE: usize = 32 + 8 + 1;
+}
+
+#[account()]
+pub struct TransactionCreationTime {
+    pub time: i64   // Matches UnixTimestamp, which is not supported by anchor idls at present
+}
+impl TransactionCreationTime {
+    pub const SEED_PREFIX: &'static [u8] = b"time_delay_creation_time";
+
+    pub const MAX_SIZE: usize = 8;
+}
+
+#[error_code]
+pub enum ErrorCode {
+    #[msg("The transaction cannot be executed yet")]
+    TooSoon,
+}

--- a/cryptid_anchor/tests/middleware/checkRecipient.ts
+++ b/cryptid_anchor/tests/middleware/checkRecipient.ts
@@ -4,19 +4,19 @@ import chaiAsPromised from "chai-as-promised";
 import {
     cryptidTransferInstruction,
     deriveCryptidAccountAddressWithMiddleware,
-    deriveMiddlewareAccountAddress,
+    deriveCheckRecipientMiddlewareAccountAddress,
     toAccountMeta
 } from "../util/cryptid";
 import {initializeDIDAccount} from "../util/did";
 import {fund, createTestContext, balanceOf} from "../util/anchorUtils";
 import {DID_SOL_PROGRAM} from "@identity.com/sol-did-client";
 import {InstructionData} from "../util/types";
-import {CHECK_RECIPIENT_MIDDLEWARE_PROGRAM, CRYPTID_PROGRAM} from "../util/constants";
+import {CRYPTID_PROGRAM} from "../util/constants";
 
 chai.use(chaiAsPromised);
 const {expect} = chai;
 
-describe("checkRecipient", () => {
+describe("Middleware: checkRecipient", () => {
     const {
         program,
         authority,
@@ -87,7 +87,7 @@ describe("checkRecipient", () => {
     })
 
     before('Set up middleware PDA', async () => {
-        [middlewareAccount, middlewareBump] = await deriveMiddlewareAccountAddress(CHECK_RECIPIENT_MIDDLEWARE_PROGRAM, authority.publicKey, 0);
+        [middlewareAccount, middlewareBump] = await deriveCheckRecipientMiddlewareAccountAddress(authority.publicKey, 0);
 
         await checkRecipientMiddlewareProgram.methods.create(recipient.publicKey, 0, middlewareBump).accounts({
             middlewareAccount,

--- a/cryptid_anchor/tests/middleware/timeDelay.ts
+++ b/cryptid_anchor/tests/middleware/timeDelay.ts
@@ -1,0 +1,189 @@
+import {Keypair, LAMPORTS_PER_SOL, PublicKey, SystemProgram} from "@solana/web3.js";
+import chai from 'chai';
+import chaiAsPromised from "chai-as-promised";
+import {
+    cryptidTransferInstruction,
+    deriveCryptidAccountAddressWithMiddleware,
+    deriveTimeDelayMiddlewareAccountAddress, deriveTimeDelayTransactionStateMiddlewareAccountAddress,
+    toAccountMeta
+} from "../util/cryptid";
+import {initializeDIDAccount} from "../util/did";
+import {fund, createTestContext, balanceOf, sleep} from "../util/anchorUtils";
+import {DID_SOL_PROGRAM} from "@identity.com/sol-did-client";
+import {InstructionData} from "../util/types";
+import {CRYPTID_PROGRAM} from "../util/constants";
+import BN from "bn.js";
+
+chai.use(chaiAsPromised);
+const {expect} = chai;
+
+describe("Middleware: timeDelay", () => {
+    const {
+        program,
+        authority,
+        middleware: {
+            timeDelay: timeDelayMiddlewareProgram,
+        }
+    } = createTestContext();
+
+    let didAccount: PublicKey;
+
+    // this middleware allows the transaction to be executed after a delay of 100s
+    let slowMiddlewareAccount: PublicKey;
+    let slowMiddlewareBump: number;
+
+    // this middleware allows the transaction to be executed after a delay of 1s
+    let fastMiddlewareAccount: PublicKey;
+    let fastMiddlewareBump: number;
+
+    let slowCryptidAccount: PublicKey;
+    let slowCryptidBump: number;
+
+    let fastCryptidAccount: PublicKey;
+    let fastCryptidBump: number;
+
+    let recipient = Keypair.generate();
+    const transferInstructionData = cryptidTransferInstruction(LAMPORTS_PER_SOL); // 1 SOL
+
+    const propose = async (cryptidAccount: PublicKey, transactionAccount: Keypair, instruction: InstructionData = transferInstructionData) =>
+        program.methods.proposeTransaction(
+            [instruction],
+            2,
+        ).accounts({
+                cryptidAccount,
+                authority: authority.publicKey,
+                transactionAccount: transactionAccount.publicKey
+            }
+        ).remainingAccounts([
+                toAccountMeta(recipient.publicKey, true, false),
+                toAccountMeta(SystemProgram.programId)
+            ]
+        ).signers(
+            [transactionAccount]
+        ).rpc({skipPreflight: true}); // skip preflight so we see validator logs on error
+
+    const execute = (cryptidAccount: PublicKey, cryptidBump: number, transactionAccount: Keypair, middlewareAccount: PublicKey) =>
+        // execute the Cryptid transaction
+        program.methods.executeTransaction(
+            Buffer.from([]),  // no controller chain
+            middlewareAccount,
+            cryptidBump,
+            0
+        ).accounts({
+                cryptidAccount,
+                didProgram: DID_SOL_PROGRAM,
+                did: didAccount,
+                signer: authority.publicKey,
+                destination: authority.publicKey,
+                transactionAccount: transactionAccount.publicKey
+            }
+        ).remainingAccounts([
+            toAccountMeta(recipient.publicKey, true, false),
+            toAccountMeta(SystemProgram.programId)
+        ]).rpc({skipPreflight: true}); // skip preflight so we see validator logs on error
+
+    const registerTransactionState = async (transactionAccount: Keypair, middlewareAccount: PublicKey): Promise<[PublicKey, number]> => {
+        const [transactionStateAddress, transactionStateBump] = await deriveTimeDelayTransactionStateMiddlewareAccountAddress(transactionAccount.publicKey);
+        await timeDelayMiddlewareProgram.methods.registerTransaction().accounts({
+                middlewareAccount,
+                transactionAccount: transactionAccount.publicKey,
+                transactionCreateTime: transactionStateAddress,
+                authority: authority.publicKey,
+            }
+        ).rpc({skipPreflight: true}); // skip preflight so we see validator logs on error
+
+        return [transactionStateAddress, transactionStateBump]
+    }
+
+    const timeDelay = (transactionAccount: Keypair, middlewareAccount: PublicKey, transactionState: PublicKey, transactionStateBump: number) =>
+        // execute the check recipient middleware, to ensure that the correct recipient is used in the tx
+        timeDelayMiddlewareProgram.methods.executeMiddleware(transactionStateBump).accounts({
+                middlewareAccount,
+                transactionAccount: transactionAccount.publicKey,
+                destination: authority.publicKey,
+                transactionCreateTime: transactionState,
+                cryptidProgram: CRYPTID_PROGRAM
+            }
+        ).rpc({skipPreflight: true}); // skip preflight so we see validator logs on error
+
+    before('Set up DID account', async () => {
+        await fund(authority.publicKey, 10 * LAMPORTS_PER_SOL);
+        didAccount = await initializeDIDAccount(authority);
+    })
+
+    before('Set up middleware PDA', async () => {
+        [slowMiddlewareAccount, slowMiddlewareBump] = await deriveTimeDelayMiddlewareAccountAddress(authority.publicKey, 100);
+        [fastMiddlewareAccount, fastMiddlewareBump] = await deriveTimeDelayMiddlewareAccountAddress(authority.publicKey, 1);
+
+        // create a time-delay middleware that blocks for one epoch
+        await timeDelayMiddlewareProgram.methods.create(new BN(100), slowMiddlewareBump).accounts({
+            middlewareAccount: slowMiddlewareAccount,
+            authority: authority.publicKey,
+        }).rpc({skipPreflight: true});
+
+        await timeDelayMiddlewareProgram.methods.create(new BN(1), fastMiddlewareBump).accounts({
+            middlewareAccount: fastMiddlewareAccount,
+            authority: authority.publicKey,
+        }).rpc({skipPreflight: true});
+    })
+
+    before('Set up generative Cryptid Account with middleware', async () => {
+        [slowCryptidAccount, slowCryptidBump] = await deriveCryptidAccountAddressWithMiddleware(didAccount, slowMiddlewareAccount);
+        [fastCryptidAccount, fastCryptidBump] = await deriveCryptidAccountAddressWithMiddleware(didAccount, fastMiddlewareAccount);
+
+        if (!process.env.QUIET) {
+            console.log("Accounts", {
+                didAccount: didAccount.toBase58(),
+                slowCryptidAccount: slowCryptidAccount.toBase58(),
+                slowMiddlewareAccount: slowMiddlewareAccount.toBase58(),
+                fastCryptidAccount: fastCryptidAccount.toBase58(),
+                fastMiddlewareAccount: fastMiddlewareAccount.toBase58(),
+                authority: authority.publicKey.toBase58(),
+                recipient: recipient.publicKey.toBase58(),
+            })
+        }
+
+        await fund(slowCryptidAccount, 20 * LAMPORTS_PER_SOL);
+        await fund(fastCryptidAccount, 20 * LAMPORTS_PER_SOL);
+    })
+
+    it("cannot immediately execute a transfer", async () => {
+        const transactionAccount = Keypair.generate();
+
+        // propose the Cryptid transaction
+        await propose(slowCryptidAccount, transactionAccount);
+
+        // register the transaction state
+        const [transactionState, transactionStateBump] = await registerTransactionState(transactionAccount, slowMiddlewareAccount);
+
+        // attempt to pass through the middleware
+        const shouldFail = timeDelay(transactionAccount, slowMiddlewareAccount, transactionState, transactionStateBump);
+
+        // TODO expose the error message
+        return expect(shouldFail).to.be.rejected;
+    });
+
+    it("can execute a transfer after waiting", async () => {
+        const previousBalance = await balanceOf(fastCryptidAccount);
+
+        const transactionAccount = Keypair.generate();
+
+        // propose the Cryptid transaction
+        await propose(fastCryptidAccount, transactionAccount);
+
+        // register the transaction state
+        const [transactionState, transactionStateBump] = await registerTransactionState(transactionAccount, fastMiddlewareAccount);
+
+        // wait for the transaction to be ready
+        await sleep(2000);
+
+        // pass through the middleware
+        await timeDelay(transactionAccount, fastMiddlewareAccount, transactionState, transactionStateBump);
+
+        // execute the Cryptid transaction
+        await execute(fastCryptidAccount, fastCryptidBump, transactionAccount, fastMiddlewareAccount);
+
+        const currentBalance = await balanceOf(fastCryptidAccount);
+        expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed
+    });
+});

--- a/cryptid_anchor/tests/util/anchorUtils.ts
+++ b/cryptid_anchor/tests/util/anchorUtils.ts
@@ -3,11 +3,13 @@ import {AnchorProvider, Program, Provider} from "@project-serum/anchor";
 import * as anchor from "@project-serum/anchor";
 import {CryptidAnchor} from "../../target/types/cryptid_anchor";
 import {CheckRecipient} from "../../target/types/check_recipient";
+import {TimeDelay} from "../../target/types/time_delay";
 
 const envProvider = anchor.AnchorProvider.env();
 const envProgram = anchor.workspace.CryptidAnchor as Program<CryptidAnchor>;
 
 const envCheckRecipientMiddlewareProgram = anchor.workspace.CheckRecipient as Program<CheckRecipient>;
+const envTimeDelayMiddlewareProgram = anchor.workspace.TimeDelay as Program<TimeDelay>;
 
 if (!process.env.QUIET) {
     envProvider.connection.onLogs("all", (log) =>
@@ -36,6 +38,7 @@ export type CryptidTestContext = {
     keypair: Keypair,
     middleware: {
         checkRecipient : Program<CheckRecipient>
+        timeDelay : Program<TimeDelay>
     }
 }
 
@@ -48,6 +51,7 @@ export const createTestContext = (): CryptidTestContext => {
     const authority = provider.wallet;
 
     const checkRecipientMiddlewareProgram = new Program<CheckRecipient>(envCheckRecipientMiddlewareProgram.idl, envCheckRecipientMiddlewareProgram.programId, anchorProvider);
+    const timeDelayMiddlewareProgram = new Program<TimeDelay>(envTimeDelayMiddlewareProgram.idl, envTimeDelayMiddlewareProgram.programId, anchorProvider);
 
     return {
         program,
@@ -55,7 +59,10 @@ export const createTestContext = (): CryptidTestContext => {
         authority,
         keypair,
         middleware: {
-            checkRecipient: checkRecipientMiddlewareProgram
+            checkRecipient: checkRecipientMiddlewareProgram,
+            timeDelay: timeDelayMiddlewareProgram
         }
     }
 };
+
+export const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));

--- a/cryptid_anchor/tests/util/constants.ts
+++ b/cryptid_anchor/tests/util/constants.ts
@@ -4,6 +4,6 @@ import {ExtendedCluster} from "@identity.com/sol-did-client";
 export const CRYPTID_PROGRAM = new PublicKey('Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS');
 
 export const CHECK_RECIPIENT_MIDDLEWARE_PROGRAM = new PublicKey('midcHDoZsxvMmNtUr8howe8MWFrJeHHPbAyJF1nHvyf');
-export const CHECK_PASS_MIDDLEWARE_PROGRAM = new PublicKey('midpT1DeQGnKUjmGbEtUMyugXL5oEBeXU3myBMntkKo');
+export const TIME_DELAY_MIDDLEWARE_PROGRAM = new PublicKey('midttN2h6G2CBvt1kpnwUsFXM6Gv7gratVwuo2XhSNk');
 
 export const CLUSTER: ExtendedCluster = 'localnet';

--- a/cryptid_anchor/tests/util/cryptid.ts
+++ b/cryptid_anchor/tests/util/cryptid.ts
@@ -1,8 +1,9 @@
 import {AccountMeta, PublicKey, SystemProgram} from "@solana/web3.js";
 import * as anchor from "@project-serum/anchor";
 import {DID_SOL_PROGRAM} from "@identity.com/sol-did-client";
-import {CRYPTID_PROGRAM} from "./constants";
+import {CHECK_RECIPIENT_MIDDLEWARE_PROGRAM, CRYPTID_PROGRAM, TIME_DELAY_MIDDLEWARE_PROGRAM} from "./constants";
 import {InstructionData, TransactionAccountMeta} from "./types";
+import BN from "bn.js";
 
 export const toAccountMeta = (publicKey: PublicKey, isWritable: boolean = false, isSigner: boolean = false): AccountMeta => ({
     pubkey: publicKey,
@@ -61,11 +62,28 @@ export const deriveCryptidAccountAddressWithMiddleware = (didAccount: PublicKey,
     CRYPTID_PROGRAM
 );
 
-export const deriveMiddlewareAccountAddress = (middlewareProgramId: PublicKey, authority: PublicKey, nonce: number): Promise<[PublicKey, number]> => PublicKey.findProgramAddress(
+export const deriveCheckRecipientMiddlewareAccountAddress = (authority: PublicKey, nonce: number): Promise<[PublicKey, number]> => PublicKey.findProgramAddress(
     [
         anchor.utils.bytes.utf8.encode("check_recipient"),
         authority.toBuffer(),
         Buffer.from([nonce]),
     ],
-    middlewareProgramId
+    CHECK_RECIPIENT_MIDDLEWARE_PROGRAM
+);
+
+export const deriveTimeDelayMiddlewareAccountAddress = (authority: PublicKey, seconds: number): Promise<[PublicKey, number]> => PublicKey.findProgramAddress(
+    [
+        anchor.utils.bytes.utf8.encode("time_delay"),
+        authority.toBuffer(),
+        new BN(seconds).toArrayLike(Buffer, "le", 8),
+    ],
+    TIME_DELAY_MIDDLEWARE_PROGRAM
+);
+
+export const deriveTimeDelayTransactionStateMiddlewareAccountAddress = (transaction_account: PublicKey): Promise<[PublicKey, number]> => PublicKey.findProgramAddress(
+    [
+        anchor.utils.bytes.utf8.encode("time_delay_creation_time"),
+        transaction_account.toBuffer()
+    ],
+    TIME_DELAY_MIDDLEWARE_PROGRAM
 );


### PR DESCRIPTION
Adds a middleware that specifies a time delay. A transaction can be queued up, but can not be executed until a delay has passed.

This is a simple permissionless safety mechanism that can be added to a cryptid account.

It protects, for example, against attacks that trick a user into signing a transaction to move funds out of their cryptid account. The transaction can be created, but the attacker must trick a user a second time, some time later, to execute the transaction.

This is also the first example of a middleware that has its own transaction-level state, indicating the time at which the tx was initially created. The flow for a transaction using this middleware is therefore:

Cryptid.propose -> create the tx
Middleware.registerTransaction -> register the creation time with the middleware
<<wait>>
Middleware.execute -> approves the transaction if enough time has passed
Cryptid.execute -> executes the transaction