### PR TITLE
Safety mechanisms to avoid replay attacks on propose/execute.

### DIFF
--- a/cryptid_anchor/client/packages/idl/cryptid_anchor.ts
+++ b/cryptid_anchor/client/packages/idl/cryptid_anchor.ts
@@ -333,6 +333,17 @@ export type CryptidAnchor = {
               "This is used to prevent replay attacks TODO: Do we need it?"
             ],
             "type": "u8"
+          },
+          {
+            "name": "state",
+            "docs": [
+              "The transaction state, to prevent replay attacks",
+              "in case an executed transaction account is not immediately",
+              "garbage-collected by the runtime"
+            ],
+            "type": {
+              "defined": "TransactionState"
+            }
           }
         ]
       }
@@ -465,58 +476,53 @@ export type CryptidAnchor = {
     },
     {
       "code": 6003,
+      "name": "WrongCryptidAccount",
+      "msg": "Wrong Cryptid account program"
+    },
+    {
+      "code": 6004,
       "name": "SubInstructionError",
       "msg": "Error in sub-instruction"
     },
     {
-      "code": 6004,
+      "code": 6005,
       "name": "InvalidTransactionState",
       "msg": "Invalid transaction state"
     },
     {
-      "code": 6005,
+      "code": 6006,
       "name": "AccountMismatch",
       "msg": "An account in the transaction accounts did not match what was expected"
     },
     {
-      "code": 6006,
+      "code": 6007,
       "name": "KeyCannotChangeTransaction",
       "msg": "Key is not a proposer for the transaction"
     },
     {
-      "code": 6007,
+      "code": 6008,
       "name": "KeyMustBeSigner",
       "msg": "Signer is not authorised to sign for this Cryptid account"
     },
     {
-      "code": 6008,
+      "code": 6009,
       "name": "IndexOutOfRange",
       "msg": "Index out of range."
     },
     {
-      "code": 6009,
+      "code": 6010,
       "name": "NoAccountFromSeeds",
       "msg": "No account from seeds."
     },
     {
-      "code": 6010,
+      "code": 6011,
       "name": "AccountNotFromSeeds",
       "msg": "Account not from seeds."
     },
     {
-      "code": 6011,
-      "name": "MiddlewareDidNotApprove",
-      "msg": "The required middleware did not approve the transaction."
-    },
-    {
       "code": 6012,
-      "name": "UnexpectedMiddleware",
-      "msg": "A middleware approved the transaction that was not registered on the cryptid account."
-    },
-    {
-      "code": 6013,
       "name": "IncorrectMiddleware",
-      "msg": "A different middleware approved the transaction to the one registered on the cryptid account."
+      "msg": "The expected middleware did not approve the transaction."
     }
   ]
 };
@@ -856,6 +862,17 @@ export const IDL: CryptidAnchor = {
               "This is used to prevent replay attacks TODO: Do we need it?"
             ],
             "type": "u8"
+          },
+          {
+            "name": "state",
+            "docs": [
+              "The transaction state, to prevent replay attacks",
+              "in case an executed transaction account is not immediately",
+              "garbage-collected by the runtime"
+            ],
+            "type": {
+              "defined": "TransactionState"
+            }
           }
         ]
       }
@@ -988,58 +1005,53 @@ export const IDL: CryptidAnchor = {
     },
     {
       "code": 6003,
+      "name": "WrongCryptidAccount",
+      "msg": "Wrong Cryptid account program"
+    },
+    {
+      "code": 6004,
       "name": "SubInstructionError",
       "msg": "Error in sub-instruction"
     },
     {
-      "code": 6004,
+      "code": 6005,
       "name": "InvalidTransactionState",
       "msg": "Invalid transaction state"
     },
     {
-      "code": 6005,
+      "code": 6006,
       "name": "AccountMismatch",
       "msg": "An account in the transaction accounts did not match what was expected"
     },
     {
-      "code": 6006,
+      "code": 6007,
       "name": "KeyCannotChangeTransaction",
       "msg": "Key is not a proposer for the transaction"
     },
     {
-      "code": 6007,
+      "code": 6008,
       "name": "KeyMustBeSigner",
       "msg": "Signer is not authorised to sign for this Cryptid account"
     },
     {
-      "code": 6008,
+      "code": 6009,
       "name": "IndexOutOfRange",
       "msg": "Index out of range."
     },
     {
-      "code": 6009,
+      "code": 6010,
       "name": "NoAccountFromSeeds",
       "msg": "No account from seeds."
     },
     {
-      "code": 6010,
+      "code": 6011,
       "name": "AccountNotFromSeeds",
       "msg": "Account not from seeds."
     },
     {
-      "code": 6011,
-      "name": "MiddlewareDidNotApprove",
-      "msg": "The required middleware did not approve the transaction."
-    },
-    {
       "code": 6012,
-      "name": "UnexpectedMiddleware",
-      "msg": "A middleware approved the transaction that was not registered on the cryptid account."
-    },
-    {
-      "code": 6013,
       "name": "IncorrectMiddleware",
-      "msg": "A different middleware approved the transaction to the one registered on the cryptid account."
+      "msg": "The expected middleware did not approve the transaction."
     }
   ]
 };

--- a/cryptid_anchor/programs/cryptid_anchor/src/error.rs
+++ b/cryptid_anchor/programs/cryptid_anchor/src/error.rs
@@ -14,6 +14,9 @@ pub enum CryptidError {
     /// Wrong DID Program passed
     #[msg("Wrong DID program")]
     WrongDIDProgram,
+    /// Wrong Cryptid account passed
+    #[msg("Wrong Cryptid account program")]
+    WrongCryptidAccount,
     /// Sub-instruction threw an error
     #[msg("Error in sub-instruction")]
     SubInstructionError,
@@ -38,13 +41,7 @@ pub enum CryptidError {
     /// Error validating a PDA from a set of seeds
     #[msg("Account not from seeds.")]
     AccountNotFromSeeds,
-    /// The required middleware did not approve the transaction
-    #[msg("The required middleware did not approve the transaction.")]
-    MiddlewareDidNotApprove,
-    /// A middleware approved the transaction that was not registered on the cryptid account
-    #[msg("A middleware approved the transaction that was not registered on the cryptid account.")]
-    UnexpectedMiddleware,
-    /// A different middleware approved the transaction to the one registered on the cryptid account
-    #[msg("A different middleware approved the transaction to the one registered on the cryptid account.")]
+    /// The expected middleware did not approve the transaction
+    #[msg("The expected middleware did not approve the transaction.")]
     IncorrectMiddleware,
 }

--- a/cryptid_anchor/programs/cryptid_anchor/src/instructions/approve_execution.rs
+++ b/cryptid_anchor/programs/cryptid_anchor/src/instructions/approve_execution.rs
@@ -1,10 +1,16 @@
+use crate::error::CryptidError;
 use crate::state::transaction_account::TransactionAccount;
+use crate::state::transaction_state::TransactionState;
 use anchor_lang::prelude::*;
 
 #[derive(Accounts)]
 pub struct ApproveExecution<'info> {
     pub middleware_account: Signer<'info>,
-    #[account(mut)]
+    #[account(
+        mut,
+        // ensure the transaction is not approved until it is ready to be approved, and is not executed
+        constraint = transaction_account.state == TransactionState::Ready @ CryptidError::InvalidTransactionState,
+    )]
     pub transaction_account: Account<'info, TransactionAccount>,
 }
 

--- a/cryptid_anchor/programs/cryptid_anchor/src/instructions/propose_transaction.rs
+++ b/cryptid_anchor/programs/cryptid_anchor/src/instructions/propose_transaction.rs
@@ -1,6 +1,7 @@
 use crate::state::abbreviated_instruction_data::AbbreviatedInstructionData;
 use crate::state::instruction_size::InstructionSize;
 use crate::state::transaction_account::TransactionAccount;
+use crate::state::transaction_state::TransactionState;
 use anchor_lang::prelude::*;
 
 #[derive(Accounts)]
@@ -43,6 +44,8 @@ pub fn propose_transaction<'a, 'b, 'c, 'info>(
     ctx.accounts.transaction_account.instructions = instructions;
     ctx.accounts.transaction_account.cryptid_account = *ctx.accounts.cryptid_account.key;
     ctx.accounts.transaction_account.approved_middleware = None;
+    // Extending transactions is not yet supported, so transactions are initialised in Ready state
+    ctx.accounts.transaction_account.state = TransactionState::Ready;
 
     // Accounts stored into the transaction account are referenced by
     // the abbreviated instruction data by index

--- a/cryptid_anchor/programs/cryptid_anchor/src/instructions/util.rs
+++ b/cryptid_anchor/programs/cryptid_anchor/src/instructions/util.rs
@@ -1,5 +1,4 @@
 use crate::error::CryptidError;
-use crate::state::transaction_account::TransactionAccount;
 use anchor_lang::prelude::*;
 use bitflags::bitflags;
 use num_traits::cast::ToPrimitive;
@@ -84,36 +83,5 @@ bitflags! {
     pub struct ExecuteFlags: u8{
         /// Print debug logs, uses a large portion of the compute budget
         const DEBUG = 1 << 0;
-    }
-}
-
-pub fn verify_middleware(
-    transaction_account: &TransactionAccount,
-    middleware_account: &Option<Pubkey>,
-) -> Result<()> {
-    match transaction_account.approved_middleware {
-        Some(approved_middleware) => {
-            match middleware_account {
-                // no middleware needed, but provided
-                None => err!(CryptidError::UnexpectedMiddleware),
-                // middleware needed and provided, check it is the correct one
-                Some(middleware) => {
-                    require_keys_eq!(
-                        approved_middleware,
-                        *middleware,
-                        CryptidError::IncorrectMiddleware
-                    );
-                    Ok(())
-                }
-            }
-        }
-        None => {
-            match middleware_account {
-                // no middleware needed or provided
-                None => Ok(()),
-                // middleware needed, but not provided
-                Some(_) => err!(CryptidError::MiddlewareDidNotApprove),
-            }
-        }
     }
 }

--- a/cryptid_anchor/programs/cryptid_anchor/src/state/transaction_state.rs
+++ b/cryptid_anchor/programs/cryptid_anchor/src/state/transaction_state.rs
@@ -3,7 +3,7 @@ use anchor_lang::prelude::*;
 /// A [`TransactionAccount`]'s state
 #[derive(Clone, Debug, AnchorDeserialize, AnchorSerialize, PartialEq)]
 pub enum TransactionState {
-    /// Transaction account is not ready to execute
+    /// Transaction account is not ready to execute - it is waiting for additional instructions to be added
     NotReady,
     /// Transaction account is ready to execute
     Ready,


### PR DESCRIPTION
In the unlikely scenario that a TransactionAccount is not garbage-collected by the runtime after the transaction is executed, this marks it as executed so that it cannot be reused.

Additionally, a check is added to ensure that middlewares do not approve transactions that are not in Ready state.