### PR TITLE
IDCOM-2105 Cleanup client service

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -13,6 +13,11 @@ overrides:
 ignorePatterns:
   - packages/**/node_modules
   - packages/**/dist
+  - dist
+  - target
+# Temporarily excluded until updated to v2
+  - wallet
+  - frontend-tests
 env:
   node: true
   mocha: true

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,8 +1,0 @@
-
-.anchor
-.DS_Store
-target
-node_modules
-dist
-build
-test-ledger

--- a/packages/client/core/src/api/abstractCryptidClient.ts
+++ b/packages/client/core/src/api/abstractCryptidClient.ts
@@ -60,17 +60,7 @@ export abstract class AbstractCryptidClient implements CryptidClient {
 
   async sign(transaction: Transaction): Promise<Transaction> {
     const cryptidService = await this.service();
-    const cryptidTx = await cryptidService.directExecute(
-      this.details,
-      transaction
-    );
-    // TODO why do we need this, if we are adding the wallet to the anchor provider?
-    // Anchor should be signing the transaction for us already
-    cryptidTx.recentBlockhash = await this.options.connection
-      .getLatestBlockhash()
-      .then((blockhash) => blockhash.blockhash);
-    cryptidTx.feePayer = this.wallet.publicKey;
-    return this.wallet.signTransaction(cryptidTx);
+    return cryptidService.directExecute(this.details, transaction);
   }
 
   async signLarge(transaction: Transaction): Promise<{
@@ -139,7 +129,9 @@ export abstract class AbstractCryptidClient implements CryptidClient {
 
     // TODO clean up
     if (result.value.err)
-      throw new Error("Transaction failed: " + result.value.err);
+      throw new Error(
+        "Transaction failed: " + JSON.stringify(result.value.err)
+      );
 
     return txSig;
   }


### PR DESCRIPTION
All tx execution functions use the same signing function now, and cleaned up some eslint/prettier config (removed the obsolete prettierignore file and added ignore paths to eslintrc)