### PR TITLE
IDCOM-2126 Add an optional failsafe key to the checkPass middleware

### DIFF
--- a/packages/client/cli/package.json
+++ b/packages/client/cli/package.json
@@ -17,7 +17,7 @@
     "/oclif.manifest.json"
   ],
   "dependencies": {
-    "@identity.com/cryptid": "0.3.0-alpha.3",
+    "@identity.com/cryptid": "0.3.0-alpha.4",
     "@oclif/core": "^1.13.10",
     "@oclif/plugin-help": "^5",
     "@oclif/plugin-plugins": "^2.0.1",

--- a/packages/client/core/package.json
+++ b/packages/client/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/cryptid-core",
-  "version": "0.3.0-alpha.3",
+  "version": "0.3.0-alpha.4",
   "scripts": {
     "clean": "rimraf dist",
     "lint": "eslint src/**/*.ts",
@@ -13,7 +13,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@identity.com/cryptid-idl": "0.3.0-alpha.3",
+    "@identity.com/cryptid-idl": "0.3.0-alpha.4",
     "@identity.com/sol-did-client": "^3.1.0",
     "@project-serum/anchor": "^0.25.0",
     "@solana/web3.js": "^1.62.0",

--- a/packages/client/core/src/api/abstractCryptidClient.ts
+++ b/packages/client/core/src/api/abstractCryptidClient.ts
@@ -19,7 +19,7 @@ import { TransactionAccount } from "../types";
 import { ProposalResult } from "../types/cryptid";
 
 export abstract class AbstractCryptidClient implements CryptidClient {
-  protected details: CryptidAccountDetails;
+  readonly details: CryptidAccountDetails;
   protected options: CryptidOptions;
 
   protected constructor(

--- a/packages/client/core/src/api/cryptidClient.ts
+++ b/packages/client/core/src/api/cryptidClient.ts
@@ -8,6 +8,7 @@ import {
 import { DIDDocument } from "did-resolver";
 import { Wallet } from "../types/crypto";
 import { ProposalResult, TransactionAccount } from "../types";
+import { CryptidAccountDetails } from "../lib/CryptidAccountDetails";
 
 export type PayerOption = "DID_PAYS" | "SIGNER_PAYS";
 export type CryptidOptions = {
@@ -50,6 +51,11 @@ export interface CryptidClient {
    * The DID that owns this Cryptid instance
    */
   readonly did: string;
+
+  /**
+   * The details behind the cryptid account (address, owner, etc).
+   */
+  readonly details: CryptidAccountDetails;
 
   /**
    * Signs a transaction from the DID. Returns a meta-transaction

--- a/packages/client/cryptid/package.json
+++ b/packages/client/cryptid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/cryptid",
-  "version": "0.3.0-alpha.3",
+  "version": "0.3.0-alpha.4",
   "scripts": {
     "clean": "rimraf dist",
     "prebuild": "yarn clean",
@@ -13,8 +13,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@identity.com/cryptid-core": "0.3.0-alpha.3",
-    "@identity.com/cryptid-middleware-check-pass": "0.3.0-alpha.3"
+    "@identity.com/cryptid-core": "0.3.0-alpha.4",
+    "@identity.com/cryptid-middleware-check-pass": "0.3.0-alpha.4"
   },
   "devDependencies": {
     "rimraf": "^3.0.2"

--- a/packages/client/idl/package.json
+++ b/packages/client/idl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/cryptid-idl",
-  "version": "0.3.0-alpha.3",
+  "version": "0.3.0-alpha.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/packages/client/idl/src/check_pass.ts
+++ b/packages/client/idl/src/check_pass.ts
@@ -33,6 +33,12 @@ export type CheckPass = {
         {
           "name": "expireOnUse",
           "type": "bool"
+        },
+        {
+          "name": "failsafe",
+          "type": {
+            "option": "publicKey"
+          }
         }
       ]
     },
@@ -65,8 +71,9 @@ export type CheckPass = {
           "isSigner": true,
           "docs": [
             "An authority on the DID.",
-            "This is only needed for the expireOnUse case. In this case, the authority must be the owner",
-            "of the gateway token."
+            "This is needed for two cases:",
+            "1) the expireOnUse case. In this case, the authority must be the owner of the gateway token.",
+            "2) the failsafe case. In this case, the authority must match the failsafe key (if present)"
           ]
         },
         {
@@ -109,10 +116,18 @@ export type CheckPass = {
         "fields": [
           {
             "name": "gatekeeperNetwork",
+            "docs": [
+              "The gatekeeper network that this middleware checks against",
+              "If the signer presents a valid gateway token, owned either by the DID that owns the transaction",
+              "or by a key on the DID that owns the transaction, then the transaction is approved."
+            ],
             "type": "publicKey"
           },
           {
             "name": "authority",
+            "docs": [
+              "The authority creating t"
+            ],
             "type": "publicKey"
           },
           {
@@ -121,7 +136,20 @@ export type CheckPass = {
           },
           {
             "name": "expireOnUse",
+            "docs": [
+              "If true, expire a gateway token after it has been used. Note, this can only be used",
+              "with gatekeeper networks that have the ExpireFeature enabled."
+            ],
             "type": "bool"
+          },
+          {
+            "name": "failsafe",
+            "docs": [
+              "A key which, if passed as the authority, bypasses the middleware check"
+            ],
+            "type": {
+              "option": "publicKey"
+            }
           }
         ]
       }
@@ -181,6 +209,12 @@ export const IDL: CheckPass = {
         {
           "name": "expireOnUse",
           "type": "bool"
+        },
+        {
+          "name": "failsafe",
+          "type": {
+            "option": "publicKey"
+          }
         }
       ]
     },
@@ -213,8 +247,9 @@ export const IDL: CheckPass = {
           "isSigner": true,
           "docs": [
             "An authority on the DID.",
-            "This is only needed for the expireOnUse case. In this case, the authority must be the owner",
-            "of the gateway token."
+            "This is needed for two cases:",
+            "1) the expireOnUse case. In this case, the authority must be the owner of the gateway token.",
+            "2) the failsafe case. In this case, the authority must match the failsafe key (if present)"
           ]
         },
         {
@@ -257,10 +292,18 @@ export const IDL: CheckPass = {
         "fields": [
           {
             "name": "gatekeeperNetwork",
+            "docs": [
+              "The gatekeeper network that this middleware checks against",
+              "If the signer presents a valid gateway token, owned either by the DID that owns the transaction",
+              "or by a key on the DID that owns the transaction, then the transaction is approved."
+            ],
             "type": "publicKey"
           },
           {
             "name": "authority",
+            "docs": [
+              "The authority creating t"
+            ],
             "type": "publicKey"
           },
           {
@@ -269,7 +312,20 @@ export const IDL: CheckPass = {
           },
           {
             "name": "expireOnUse",
+            "docs": [
+              "If true, expire a gateway token after it has been used. Note, this can only be used",
+              "with gatekeeper networks that have the ExpireFeature enabled."
+            ],
             "type": "bool"
+          },
+          {
+            "name": "failsafe",
+            "docs": [
+              "A key which, if passed as the authority, bypasses the middleware check"
+            ],
+            "type": {
+              "option": "publicKey"
+            }
           }
         ]
       }

--- a/packages/client/middleware/checkPass/package.json
+++ b/packages/client/middleware/checkPass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/cryptid-middleware-check-pass",
-  "version": "0.3.0-alpha.3",
+  "version": "0.3.0-alpha.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
@@ -13,7 +13,7 @@
     "lint": "eslint src/**/*.ts"
   },
   "dependencies": {
-    "@identity.com/cryptid-core": "0.3.0-alpha.3",
+    "@identity.com/cryptid-core": "0.3.0-alpha.4",
     "@identity.com/solana-gateway-ts": "^0.8.2",
     "@solana/web3.js": "^1.62.0"
   }

--- a/packages/client/middleware/checkPass/src/index.ts
+++ b/packages/client/middleware/checkPass/src/index.ts
@@ -37,13 +37,15 @@ const expireFeature = new NetworkFeature({
 
 const deriveMiddlewareAccountAddress = (
   authority: PublicKey,
-  gatekeeperNetwork: PublicKey
+  gatekeeperNetwork: PublicKey,
+  failsafe?: PublicKey
 ): [PublicKey, number] =>
   PublicKey.findProgramAddressSync(
     [
       anchor.utils.bytes.utf8.encode("check_pass"),
       authority.toBuffer(),
       gatekeeperNetwork.toBuffer(),
+      failsafe?.toBuffer() || Buffer.alloc(32),
     ],
     CHECK_PASS_MIDDLEWARE_PROGRAM_ID
   );
@@ -86,7 +88,8 @@ export class CheckPassMiddleware
 
     const [middlewareAccount, middlewareBump] = deriveMiddlewareAccountAddress(
       params.authority.publicKey,
-      params.gatekeeperNetwork
+      params.gatekeeperNetwork,
+      params.failsafe
     );
 
     return program.methods

--- a/packages/client/middleware/checkPass/src/index.ts
+++ b/packages/client/middleware/checkPass/src/index.ts
@@ -57,6 +57,7 @@ export type CheckPassParameters = {
   gatekeeperNetwork: PublicKey;
   keyAlias: string;
   expirePassOnUse: boolean;
+  failsafe?: PublicKey;
 } & GenericMiddlewareParams;
 export class CheckPassMiddleware
   implements MiddlewareClient<CheckPassParameters>
@@ -89,7 +90,12 @@ export class CheckPassMiddleware
     );
 
     return program.methods
-      .create(params.gatekeeperNetwork, middlewareBump, params.expirePassOnUse)
+      .create(
+        params.gatekeeperNetwork,
+        middlewareBump,
+        params.expirePassOnUse,
+        params.failsafe || null
+      )
       .accounts({
         middlewareAccount,
         authority: params.authority.publicKey,

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -6,8 +6,8 @@
     "lint": "eslint src/**/*.ts"
   },
   "dependencies": {
-    "@identity.com/cryptid": "0.3.0-alpha.3",
-    "@identity.com/cryptid-idl": "0.3.0-alpha.3",
+    "@identity.com/cryptid": "0.3.0-alpha.4",
+    "@identity.com/cryptid-idl": "0.3.0-alpha.4",
     "@identity.com/sol-did-client": "^3.1.0",
     "@identity.com/solana-gatekeeper-lib": "^4.0.1",
     "@identity.com/solana-gateway-ts": "^0.8.2",

--- a/packages/tests/src/middleware/chaining.ts
+++ b/packages/tests/src/middleware/chaining.ts
@@ -1,0 +1,249 @@
+// import {
+//   Keypair,
+//   LAMPORTS_PER_SOL,
+//   PublicKey,
+//   SystemProgram,
+// } from "@solana/web3.js";
+// import chai from "chai";
+// import chaiAsPromised from "chai-as-promised";
+// import {
+//   cryptidTransferInstruction,
+//   deriveCheckPassMiddlewareAccountAddress,
+//   toAccountMeta,
+//   createCryptidAccount,
+//   makeTransfer,
+//   deriveTimeDelayTransactionStateMiddlewareAccountAddress,
+// } from "../util/cryptid";
+// import { addKeyToDID, initializeDIDAccount } from "../util/did";
+// import {
+//   fund,
+//   createTestContext,
+//   balanceOf,
+//   Wallet,
+// } from "../util/anchorUtils";
+// import { DID_SOL_PREFIX } from "@identity.com/sol-did-client";
+// import {
+//   addGatekeeper,
+//   getExpireFeatureAddress,
+//   sendGatewayTransaction,
+// } from "../util/gatekeeperUtils";
+// import { GatekeeperService } from "@identity.com/solana-gatekeeper-lib";
+// import { beforeEach } from "mocha";
+// import {
+//   CRYPTID_PROGRAM,
+//   CryptidClient,
+//   InstructionData,
+//   Cryptid,
+//   CheckPassMiddleware,
+// } from "@identity.com/cryptid";
+//
+// chai.use(chaiAsPromised);
+// const { expect } = chai;
+//
+// describe("Middleware chaining", () => {
+//   const {
+//     program,
+//     provider,
+//     authority,
+//     keypair,
+//     middleware: {
+//       checkPass: checkPassMiddlewareProgram,
+//       timeDelay: timeDelayMiddlewareProgram,
+//     },
+//   } = createTestContext();
+//
+//   const gatekeeper = Keypair.generate();
+//   let gatekeeperNetwork: Keypair;
+//   let gatekeeperService: GatekeeperService;
+//   // The address of the expire-on-use feature for the gatekeeper network,
+//   // if it exists.
+//   let expireFeatureAccount: PublicKey;
+//
+//   let didAccount: PublicKey;
+//   let cryptidAccount: PublicKey;
+//   let cryptidBump: number;
+//   let cryptidIndex = 0; // The index of the cryptid account owned by that DID - increment when creating a new account
+//   let cryptid: CryptidClient;
+//
+//   let checkPassMiddlewareAccount: PublicKey;
+//   let checkPassMiddlewareBump: number;
+//
+//   let timeDelayMiddlewareAccount: PublicKey;
+//   let timeDelayMiddlewareBump: number;
+//
+//   const recipient = Keypair.generate();
+//   const transferInstructionData = cryptidTransferInstruction(LAMPORTS_PER_SOL); // 1 SOL
+//
+//   const createGatewayToken = (owner: PublicKey) =>
+//       sendGatewayTransaction(() => gatekeeperService.issue(owner));
+//
+//   const revokeGatewayToken = (gatewayToken: PublicKey) =>
+//       sendGatewayTransaction(() => gatekeeperService.revoke(gatewayToken));
+//
+//   const getGatewayToken = (owner: PublicKey) =>
+//       gatekeeperService.findGatewayTokenForOwner(owner);
+//
+//   const setUpCheckPassMiddleware = async () => {
+//     [checkPassMiddlewareAccount, checkPassMiddlewareBump] =
+//         deriveCheckPassMiddlewareAccountAddress(
+//             authority.publicKey,
+//             gatekeeperNetwork.publicKey,
+//             null,
+//             null
+//         );
+//     const transaction = await new CheckPassMiddleware().createMiddleware({
+//       authority,
+//       connection: provider.connection,
+//       expirePassOnUse: false,
+//       keyAlias: "cold",
+//       opts: {},
+//       gatekeeperNetwork: gatekeeperNetwork.publicKey,
+//     });
+//
+//     await provider.sendAndConfirm(transaction, [keypair]);
+//   };
+//
+//   const setUpTimeDelayMiddleware = async () => {
+//     [timeDelayMiddlewareAccount, timeDelayMiddlewareBump] =
+//         deriveTimeDelayTransactionStateMiddlewareAccountAddress(
+//             authority.publicKey
+//         );
+//     const transaction = await new TimeDelayMiddleware().createMiddleware({
+//       authority,
+//       connection: provider.connection,
+//       expirePassOnUse: false,
+//       keyAlias: "cold",
+//       opts: {},
+//       gatekeeperNetwork: gatekeeperNetwork.publicKey,
+//     });
+//
+//     await provider.sendAndConfirm(transaction, [keypair]);
+//   };
+//
+//   const setUpCryptidClient = async (signer: Wallet | Keypair = authority) => {
+//     const middleware = [
+//       {
+//         programId: checkPassMiddlewareProgram.programId,
+//         address: checkPassMiddlewareAccount,
+//       },
+//       {
+//         programId: timeDelayMiddlewareProgram.programId,
+//         address: checkPassMiddlewareAccount,
+//       },
+//     ];
+//
+//     cryptid = await Cryptid.createFromDID(
+//         DID_SOL_PREFIX + ":" + authority.publicKey,
+//         signer,
+//         middleware,
+//         { connection: provider.connection, accountIndex: ++cryptidIndex }
+//     );
+//
+//     await fund(cryptid.address(), 20 * LAMPORTS_PER_SOL);
+//   };
+//
+//   const makeTransaction = () =>
+//       makeTransfer(cryptid.address(), recipient.publicKey);
+//
+//   before("Set up DID account", async () => {
+//     await fund(authority.publicKey, 10 * LAMPORTS_PER_SOL);
+//     didAccount = await initializeDIDAccount(authority);
+//   });
+//
+//   before("Fund the gatekeeper", () => fund(gatekeeper.publicKey));
+//
+//   // Create a new gatekeeper network each test to allow multiple gateway tokens to be issued
+//   beforeEach("Set up a gatekeeper network and gatekeeper", async () => {
+//     gatekeeperNetwork = Keypair.generate();
+//     await fund(gatekeeperNetwork.publicKey);
+//
+//     // the expire feature account does not exist yet, but derive its address anyway
+//     // as all tests need to pass one in
+//     expireFeatureAccount = await getExpireFeatureAddress(
+//         gatekeeperNetwork.publicKey
+//     );
+//
+//     gatekeeperService = await addGatekeeper(
+//         provider,
+//         gatekeeperNetwork,
+//         gatekeeper
+//     );
+//   });
+//
+//   beforeEach("Set up middleware PDA", async () => {
+//     [checkPassMiddlewareAccount, checkPassMiddlewareBump] =
+//         deriveCheckPassMiddlewareAccountAddress(
+//             authority.publicKey,
+//             gatekeeperNetwork.publicKey
+//         );
+//     const transaction = await new CheckPassMiddleware().createMiddleware({
+//       authority,
+//       connection: provider.connection,
+//       expirePassOnUse: false,
+//       keyAlias: "cold",
+//       opts: {},
+//       gatekeeperNetwork: gatekeeperNetwork.publicKey,
+//     });
+//
+//     await provider.sendAndConfirm(transaction, [keypair]);
+//   });
+//
+//   beforeEach("Set up Cryptid Account with middleware", setUpCryptidClient);
+//
+//   it("blocks a transfer with no gateway token", async () => {
+//     // no gateway token exists for the authority
+//
+//     // send the propose tx
+//     const { proposeTransaction, transactionAccountAddress } =
+//         await cryptid.propose(makeTransaction());
+//     await cryptid.send(proposeTransaction, { skipPreflight: true });
+//
+//     // send the execute tx, which fails to pass through the middleware
+//     const [executeTransaction] = await cryptid.execute(
+//         transactionAccountAddress
+//     );
+//     const shouldFail = cryptid.send(executeTransaction, {
+//       skipPreflight: true,
+//     });
+//
+//     // TODO expose the error message
+//     return expect(shouldFail).to.be.rejected;
+//   });
+//
+//   it("allows a transfer if the authority has a valid gateway token", async () => {
+//     const previousBalance = await balanceOf(cryptid.address());
+//
+//     // issue a gateway token to the authority
+//     await createGatewayToken(authority.publicKey);
+//
+//     // send the propose tx
+//     const { proposeTransaction, transactionAccountAddress } =
+//         await cryptid.propose(makeTransaction());
+//     await cryptid.send(proposeTransaction, { skipPreflight: true });
+//
+//     // send the execute tx (executing the middleware)
+//     const [executeTransaction] = await cryptid.execute(
+//         transactionAccountAddress
+//     );
+//     await cryptid.send(executeTransaction, { skipPreflight: true });
+//
+//     const currentBalance = await balanceOf(cryptid.address());
+//     expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed
+//   });
+//
+//   it("transfers in a single transaction", async () => {
+//     const previousBalance = await balanceOf(cryptid.address());
+//
+//     // issue a gateway token to the authority
+//     await createGatewayToken(authority.publicKey);
+//
+//     const [bigTransaction] = await cryptid.proposeAndExecute(
+//         makeTransaction(),
+//         true
+//     );
+//     await cryptid.send(bigTransaction, { skipPreflight: true });
+//
+//     const currentBalance = await balanceOf(cryptid.address());
+//     expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed
+//   });
+// });

--- a/packages/tests/src/middleware/checkPass.ts
+++ b/packages/tests/src/middleware/checkPass.ts
@@ -86,7 +86,8 @@ describe("Middleware: checkPass", () => {
     [middlewareAccount, middlewareBump] =
       deriveCheckPassMiddlewareAccountAddress(
         authority.publicKey,
-        gatekeeperNetwork.publicKey
+        gatekeeperNetwork.publicKey,
+        failsafe
       );
 
     await checkPassMiddlewareProgram.methods
@@ -107,7 +108,8 @@ describe("Middleware: checkPass", () => {
     [middlewareAccount, middlewareBump] =
       deriveCheckPassMiddlewareAccountAddress(
         authority.publicKey,
-        gatekeeperNetwork.publicKey
+        gatekeeperNetwork.publicKey,
+        failsafe
       );
     const transaction = await new CheckPassMiddleware().createMiddleware({
       authority,

--- a/packages/tests/src/util/cryptid.ts
+++ b/packages/tests/src/util/cryptid.ts
@@ -108,13 +108,15 @@ export const deriveCheckRecipientMiddlewareAccountAddress = (
 
 export const deriveCheckPassMiddlewareAccountAddress = (
   authority: PublicKey,
-  gatekeeperNetwork: PublicKey
+  gatekeeperNetwork: PublicKey,
+  failsafe?: PublicKey
 ): [PublicKey, number] =>
   PublicKey.findProgramAddressSync(
     [
       anchor.utils.bytes.utf8.encode("check_pass"),
       authority.toBuffer(),
       gatekeeperNetwork.toBuffer(),
+      failsafe?.toBuffer() || Buffer.alloc(32),
     ],
     CHECK_PASS_MIDDLEWARE_PROGRAM
   );


### PR DESCRIPTION
When creating a middleware account for the checkPass middleware, a failsafe key can be added which bypasses the pass check.
This _cannot_ be changed after the middleware is created, and must be a key on the DID (otherwise the signing of the overall cryptid tx will fail.