### PR TITLE
Support generative DID use-cases

### DIFF
--- a/packages/client/idl/src/cryptid.ts
+++ b/packages/client/idl/src/cryptid.ts
@@ -73,7 +73,7 @@ export type Cryptid = {
           "isMut": false,
           "isSigner": false,
           "docs": [
-            "The DID on the Cryptid instance"
+            "The DID of the Cryptid instance"
           ]
         },
         {
@@ -182,7 +182,7 @@ export type Cryptid = {
           "isMut": false,
           "isSigner": false,
           "docs": [
-            "The DID on the Cryptid instance"
+            "The DID of the Cryptid instance"
           ]
         },
         {
@@ -607,7 +607,7 @@ export const IDL: Cryptid = {
           "isMut": false,
           "isSigner": false,
           "docs": [
-            "The DID on the Cryptid instance"
+            "The DID of the Cryptid instance"
           ]
         },
         {
@@ -716,7 +716,7 @@ export const IDL: Cryptid = {
           "isMut": false,
           "isSigner": false,
           "docs": [
-            "The DID on the Cryptid instance"
+            "The DID of the Cryptid instance"
           ]
         },
         {

--- a/packages/client/idl/src/cryptid.ts
+++ b/packages/client/idl/src/cryptid.ts
@@ -23,7 +23,7 @@ export type Cryptid = {
           "isMut": false,
           "isSigner": false,
           "docs": [
-            "The DID of the Cryptid instance"
+            "The DID on the Cryptid instance"
           ]
         },
         {
@@ -73,7 +73,7 @@ export type Cryptid = {
           "isMut": false,
           "isSigner": false,
           "docs": [
-            "The DID of the Cryptid instance"
+            "The DID on the Cryptid instance"
           ]
         },
         {
@@ -182,7 +182,7 @@ export type Cryptid = {
           "isMut": false,
           "isSigner": false,
           "docs": [
-            "The DID of the Cryptid instance"
+            "The DID on the Cryptid instance"
           ]
         },
         {
@@ -557,7 +557,7 @@ export const IDL: Cryptid = {
           "isMut": false,
           "isSigner": false,
           "docs": [
-            "The DID of the Cryptid instance"
+            "The DID on the Cryptid instance"
           ]
         },
         {
@@ -607,7 +607,7 @@ export const IDL: Cryptid = {
           "isMut": false,
           "isSigner": false,
           "docs": [
-            "The DID of the Cryptid instance"
+            "The DID on the Cryptid instance"
           ]
         },
         {
@@ -716,7 +716,7 @@ export const IDL: Cryptid = {
           "isMut": false,
           "isSigner": false,
           "docs": [
-            "The DID of the Cryptid instance"
+            "The DID on the Cryptid instance"
           ]
         },
         {

--- a/packages/tests/src/create.ts
+++ b/packages/tests/src/create.ts
@@ -2,32 +2,46 @@ import { LAMPORTS_PER_SOL } from "@solana/web3.js";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { createCryptid } from "./util/cryptid";
-import { initializeDIDAccount } from "./util/did";
-import { fund, createTestContext } from "./util/anchorUtils";
+import { getDidAccount, initializeDIDAccount } from "./util/did";
+import { fund, createTestContext, Wallet } from "./util/anchorUtils";
 
 chai.use(chaiAsPromised);
 const { expect } = chai;
 
-describe("create", () => {
-  const { authority, provider } = createTestContext();
+const testCases = [
+  {
+    name: "generative",
+    beforeFn: async (authority: Wallet) => await getDidAccount(authority),
+  },
+  {
+    name: "non-generative",
+    beforeFn: async (authority: Wallet) =>
+      await initializeDIDAccount(authority),
+  },
+];
 
-  before("Set up DID account", async () => {
-    await fund(authority.publicKey, 10 * LAMPORTS_PER_SOL);
-    await initializeDIDAccount(authority);
-  });
+testCases.forEach(({ name, beforeFn }) => {
+  describe(`create (${name})`, () => {
+    const { authority, provider } = createTestContext();
 
-  it("cannot create a zero index cryptid account", async () => {
-    const shouldFail = createCryptid(authority, {
-      connection: provider.connection,
-      accountIndex: 0,
+    before(`Set up ${name} DID account`, async () => {
+      await fund(authority.publicKey, 10 * LAMPORTS_PER_SOL);
+      await beforeFn(authority);
     });
 
-    return expect(shouldFail).to.be.rejectedWith(/CreatingWithZeroIndex/);
-  });
+    it("cannot create a zero index cryptid account", async () => {
+      const shouldFail = createCryptid(authority, {
+        connection: provider.connection,
+        accountIndex: 0,
+      });
 
-  it("can create a simple cryptid account", async () => {
-    await createCryptid(authority, {
-      connection: provider.connection,
+      return expect(shouldFail).to.be.rejectedWith(/CreatingWithZeroIndex/);
+    });
+
+    it("can create a simple cryptid account", async () => {
+      await createCryptid(authority, {
+        connection: provider.connection,
+      });
     });
   });
 });

--- a/packages/tests/src/create.ts
+++ b/packages/tests/src/create.ts
@@ -2,29 +2,17 @@ import { LAMPORTS_PER_SOL } from "@solana/web3.js";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { createCryptid } from "./util/cryptid";
-import { getDidAccount, initializeDIDAccount } from "./util/did";
-import { fund, createTestContext, Wallet } from "./util/anchorUtils";
+import { didTestCases } from "./util/did";
+import { fund, createTestContext } from "./util/anchorUtils";
 
 chai.use(chaiAsPromised);
 const { expect } = chai;
 
-const testCases = [
-  {
-    name: "generative",
-    beforeFn: async (authority: Wallet) => await getDidAccount(authority),
-  },
-  {
-    name: "non-generative",
-    beforeFn: async (authority: Wallet) =>
-      await initializeDIDAccount(authority),
-  },
-];
-
-testCases.forEach(({ name, beforeFn }) => {
-  describe(`create (${name})`, () => {
+didTestCases.forEach(({ type, beforeFn }) => {
+  describe(`create (${type})`, () => {
     const { authority, provider } = createTestContext();
 
-    before(`Set up ${name} DID account`, async () => {
+    before(`Set up ${type} account`, async () => {
       await fund(authority.publicKey, 10 * LAMPORTS_PER_SOL);
       await beforeFn(authority);
     });

--- a/packages/tests/src/directExecute.ts
+++ b/packages/tests/src/directExecute.ts
@@ -13,8 +13,8 @@ import {
   makeTransfer,
   toAccountMeta,
 } from "./util/cryptid";
-import { addKeyToDID, initializeDIDAccount } from "./util/did";
-import { fund, createTestContext, balanceOf } from "./util/anchorUtils";
+import { addKeyToDID, getDidAccount, initializeDIDAccount } from "./util/did";
+import { fund, createTestContext, balanceOf, Wallet } from "./util/anchorUtils";
 import {
   Cryptid,
   CryptidClient,
@@ -25,179 +25,199 @@ import {
 chai.use(chaiAsPromised);
 const { expect } = chai;
 
-describe("directExecute", () => {
-  const { program, authority, provider } = createTestContext();
+const testCases = [
+  {
+    name: "generative",
+    beforeFn: async (authority: Wallet) => await getDidAccount(authority),
+  },
+  {
+    name: "non-generative",
+    beforeFn: async (authority: Wallet) =>
+      await initializeDIDAccount(authority),
+  },
+];
 
-  let didAccount: PublicKey;
-  let cryptidAccount: PublicKey;
-  let cryptidBump: number;
+testCases.forEach(({ name, beforeFn }) => {
+  describe(`directExecute (${name})`, () => {
+    const { program, authority, provider } = createTestContext();
 
-  let cryptid: CryptidClient;
+    let didAccount: PublicKey;
+    let cryptidAccount: PublicKey;
+    let cryptidBump: number;
 
-  const did = DID_SOL_PREFIX + ":" + authority.publicKey;
+    let cryptid: CryptidClient;
 
-  // use this when testing directly against anchor
-  const transferInstructionData = cryptidTransferInstruction(LAMPORTS_PER_SOL); // 1 SOL
-  // use this when testing against the cryptid client
-  const makeTransaction = (recipient: PublicKey) =>
-    makeTransfer(cryptidAccount, recipient);
+    const did = DID_SOL_PREFIX + ":" + authority.publicKey;
 
-  const directExecute = (
-    recipient: Keypair,
-    instructionData: InstructionData = transferInstructionData
-  ) =>
-    program.methods
-      .directExecute(
-        Buffer.from([]), // no controller chain
-        [instructionData],
-        cryptidBump,
-        0
-      )
-      .accounts({
-        cryptidAccount,
-        didProgram: DID_SOL_PROGRAM,
-        did: didAccount,
-        signer: authority.publicKey,
-      })
-      .remainingAccounts([
-        toAccountMeta(recipient.publicKey, true, false),
-        toAccountMeta(SystemProgram.programId),
-      ])
-      .rpc({ skipPreflight: true });
-
-  before("Set up DID account", async () => {
-    await fund(authority.publicKey, 10 * LAMPORTS_PER_SOL);
-    didAccount = await initializeDIDAccount(authority);
-  });
-
-  before("Set up generative Cryptid Account", async () => {
-    [cryptidAccount, cryptidBump] = deriveCryptidAccountAddress(didAccount);
-
-    cryptid = await Cryptid.buildFromDID(did, authority, {
-      connection: provider.connection,
-    });
-
-    await fund(cryptidAccount, 20 * LAMPORTS_PER_SOL);
-  });
-
-  it("can retrieve and build the default cryptid account", async () => {
-    const cryptidDetails = await Cryptid.findAll(did, {
-      connection: provider.connection,
-    });
-
-    expect(cryptidDetails.length).to.equal(1);
-
-    Cryptid.build(cryptidDetails[0], authority, {
-      connection: provider.connection,
-    });
-  });
-
-  it("can transfer through Cryptid", async () => {
-    const recipient = Keypair.generate();
-
-    const previousBalance = await balanceOf(cryptidAccount);
-
-    const signedTransaction = await cryptid.directExecute(
-      makeTransaction(recipient.publicKey)
-    );
-    await cryptid.send(signedTransaction, { skipPreflight: true });
-
-    const currentBalance = await balanceOf(cryptidAccount);
-
-    expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Should have lost 1 SOL
-  });
-
-  it("rejects the transfer if the cryptid account is not a signer", async () => {
-    const recipient = Keypair.generate();
-
-    const instructionDataWithUnauthorisedSigner =
+    // use this when testing directly against anchor
+    const transferInstructionData =
       cryptidTransferInstruction(LAMPORTS_PER_SOL); // 1 SOL
+    // use this when testing against the cryptid client
+    const makeTransaction = (recipient: PublicKey) =>
+      makeTransfer(cryptidAccount, recipient);
 
-    // set the cryptid account as a non-signer on the transfer
-    (
-      instructionDataWithUnauthorisedSigner.accounts as TransactionAccountMeta[]
-    )[0].meta = 2; // writable but not a signer
+    const directExecute = (
+      recipient: Keypair,
+      instructionData: InstructionData = transferInstructionData
+    ) =>
+      program.methods
+        .directExecute(
+          Buffer.from([]), // no controller chain
+          [instructionData],
+          cryptidBump,
+          0
+        )
+        .accounts({
+          cryptidAccount,
+          didProgram: DID_SOL_PROGRAM,
+          did: didAccount,
+          signer: authority.publicKey,
+        })
+        .remainingAccounts([
+          toAccountMeta(recipient.publicKey, true, false),
+          toAccountMeta(SystemProgram.programId),
+        ])
+        .rpc({ skipPreflight: true });
 
-    // execute the Cryptid transaction
-    const shouldFail = directExecute(
-      recipient,
-      instructionDataWithUnauthorisedSigner
-    );
-
-    return expect(shouldFail).to.be.rejectedWith(/MissingRequiredSignature/);
-  });
-
-  it("rejects the transfer if the recipient account index is invalid", async () => {
-    const recipient = Keypair.generate();
-
-    // set the recipient account as an invalid account index
-    const instructionDataWithInvalidAccountIndex =
-      cryptidTransferInstruction(LAMPORTS_PER_SOL); // 1 SOL
-    (
-      instructionDataWithInvalidAccountIndex.accounts as TransactionAccountMeta[]
-    )[1].key = 100; // account 100 does not exist
-
-    // execute the Cryptid transaction
-    const shouldFail = directExecute(
-      recipient,
-      instructionDataWithInvalidAccountIndex
-    );
-
-    // TODO expose the error from the program
-    return expect(shouldFail).to.be.rejectedWith(/ProgramFailedToComplete/);
-  });
-
-  it("rejects the transfer if the signer is not a valid signer on the DID", async () => {
-    const recipient = Keypair.generate();
-    const bogusSigner = Keypair.generate();
-    // fund the bogus signer, otherwise the tx fails due to lack of funds, not did signing issues
-    await fund(bogusSigner.publicKey);
-
-    const bogusCryptid = await Cryptid.buildFromDID(did, bogusSigner, {
-      connection: provider.connection,
-    });
-    const signedTransaction = await bogusCryptid.directExecute(
-      makeTransaction(recipient.publicKey)
-    );
-    const shouldFail = bogusCryptid.send(signedTransaction, {
-      skipPreflight: true,
+    before("Set up DID account", async () => {
+      await fund(authority.publicKey, 10 * LAMPORTS_PER_SOL);
+      didAccount = await beforeFn(authority);
     });
 
-    // TODO expose the error from the program
-    return expect(shouldFail).to.be.rejected;
-  });
+    before("Set up generative Cryptid Account", async () => {
+      [cryptidAccount, cryptidBump] = deriveCryptidAccountAddress(didAccount);
 
-  it("can transfer through Cryptid with a second key on the DID", async () => {
-    const secondKey = Keypair.generate();
-    await fund(secondKey.publicKey);
+      cryptid = await Cryptid.buildFromDID(did, authority, {
+        connection: provider.connection,
+      });
 
-    const recipient = Keypair.generate();
-
-    const secondKeyCryptid = await Cryptid.buildFromDID(did, secondKey, {
-      connection: provider.connection,
+      await fund(cryptidAccount, 20 * LAMPORTS_PER_SOL);
     });
 
-    // thunk to execute the Cryptid transaction
-    const execute = async () => {
-      const signedTransaction = await secondKeyCryptid.directExecute(
+    it("can retrieve and build the default cryptid account", async () => {
+      const cryptidDetails = await Cryptid.findAll(did, {
+        connection: provider.connection,
+      });
+
+      expect(cryptidDetails.length).to.equal(1);
+
+      Cryptid.build(cryptidDetails[0], authority, {
+        connection: provider.connection,
+      });
+    });
+
+    it("can transfer through Cryptid", async () => {
+      const recipient = Keypair.generate();
+
+      const previousBalance = await balanceOf(cryptidAccount);
+
+      const signedTransaction = await cryptid.directExecute(
         makeTransaction(recipient.publicKey)
       );
-      await secondKeyCryptid.send(signedTransaction, { skipPreflight: true });
-    };
+      await cryptid.send(signedTransaction, { skipPreflight: true });
 
-    const previousBalance = await balanceOf(cryptidAccount);
+      const currentBalance = await balanceOf(cryptidAccount);
 
-    // should fail before the key is added:
-    expect(execute()).to.be.rejected;
+      expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Should have lost 1 SOL
+    });
 
-    // add the second key to the did
-    await addKeyToDID(authority, secondKey.publicKey);
+    it("rejects the transfer if the cryptid account is not a signer", async () => {
+      const recipient = Keypair.generate();
 
-    // should pass afterwards
-    await execute();
+      const instructionDataWithUnauthorisedSigner =
+        cryptidTransferInstruction(LAMPORTS_PER_SOL); // 1 SOL
 
-    const currentBalance = await balanceOf(cryptidAccount);
+      // set the cryptid account as a non-signer on the transfer
+      (
+        instructionDataWithUnauthorisedSigner.accounts as TransactionAccountMeta[]
+      )[0].meta = 2; // writable but not a signer
 
-    expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Should have lost 1 SOL
+      // execute the Cryptid transaction
+      const shouldFail = directExecute(
+        recipient,
+        instructionDataWithUnauthorisedSigner
+      );
+
+      return expect(shouldFail).to.be.rejectedWith(/MissingRequiredSignature/);
+    });
+
+    it("rejects the transfer if the recipient account index is invalid", async () => {
+      const recipient = Keypair.generate();
+
+      // set the recipient account as an invalid account index
+      const instructionDataWithInvalidAccountIndex =
+        cryptidTransferInstruction(LAMPORTS_PER_SOL); // 1 SOL
+      (
+        instructionDataWithInvalidAccountIndex.accounts as TransactionAccountMeta[]
+      )[1].key = 100; // account 100 does not exist
+
+      // execute the Cryptid transaction
+      const shouldFail = directExecute(
+        recipient,
+        instructionDataWithInvalidAccountIndex
+      );
+
+      // TODO expose the error from the program
+      return expect(shouldFail).to.be.rejectedWith(/ProgramFailedToComplete/);
+    });
+
+    it("rejects the transfer if the signer is not a valid signer on the DID", async () => {
+      const recipient = Keypair.generate();
+      const bogusSigner = Keypair.generate();
+      // fund the bogus signer, otherwise the tx fails due to lack of funds, not did signing issues
+      await fund(bogusSigner.publicKey);
+
+      const bogusCryptid = await Cryptid.buildFromDID(did, bogusSigner, {
+        connection: provider.connection,
+      });
+      const signedTransaction = await bogusCryptid.directExecute(
+        makeTransaction(recipient.publicKey)
+      );
+      const shouldFail = bogusCryptid.send(signedTransaction, {
+        skipPreflight: true,
+      });
+
+      // TODO expose the error from the program
+      return expect(shouldFail).to.be.rejected;
+    });
+
+    // Test-case for the non-generative DID case only.
+    if (name === "non-generative") {
+      it("can transfer through Cryptid with a second key on the DID", async () => {
+        const secondKey = Keypair.generate();
+        await fund(secondKey.publicKey);
+
+        const recipient = Keypair.generate();
+
+        const secondKeyCryptid = await Cryptid.buildFromDID(did, secondKey, {
+          connection: provider.connection,
+        });
+
+        // thunk to execute the Cryptid transaction
+        const execute = async () => {
+          const signedTransaction = await secondKeyCryptid.directExecute(
+            makeTransaction(recipient.publicKey)
+          );
+          await secondKeyCryptid.send(signedTransaction, {
+            skipPreflight: true,
+          });
+        };
+
+        const previousBalance = await balanceOf(cryptidAccount);
+
+        // should fail before the key is added:
+        expect(execute()).to.be.rejected;
+
+        // add the second key to the did
+        await addKeyToDID(authority, secondKey.publicKey);
+
+        // should pass afterwards
+        await execute();
+
+        const currentBalance = await balanceOf(cryptidAccount);
+
+        expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Should have lost 1 SOL
+      });
+    }
   });
 });

--- a/packages/tests/src/directExecute.ts
+++ b/packages/tests/src/directExecute.ts
@@ -13,8 +13,8 @@ import {
   makeTransfer,
   toAccountMeta,
 } from "./util/cryptid";
-import { addKeyToDID, getDidAccount, initializeDIDAccount } from "./util/did";
-import { fund, createTestContext, balanceOf, Wallet } from "./util/anchorUtils";
+import { addKeyToDID, didTestCases, DidTestType } from "./util/did";
+import { balanceOf, createTestContext, fund } from "./util/anchorUtils";
 import {
   Cryptid,
   CryptidClient,
@@ -25,20 +25,8 @@ import {
 chai.use(chaiAsPromised);
 const { expect } = chai;
 
-const testCases = [
-  {
-    name: "generative",
-    beforeFn: async (authority: Wallet) => await getDidAccount(authority),
-  },
-  {
-    name: "non-generative",
-    beforeFn: async (authority: Wallet) =>
-      await initializeDIDAccount(authority),
-  },
-];
-
-testCases.forEach(({ name, beforeFn }) => {
-  describe(`directExecute (${name})`, () => {
+didTestCases.forEach(({ type, beforeFn }) => {
+  describe(`directExecute (${type})`, () => {
     const { program, authority, provider } = createTestContext();
 
     let didAccount: PublicKey;
@@ -181,8 +169,8 @@ testCases.forEach(({ name, beforeFn }) => {
       return expect(shouldFail).to.be.rejected;
     });
 
-    // Test-case for the non-generative DID case only.
-    if (name === "non-generative") {
+    // Test-case for the initialized DID case only.
+    if (type === DidTestType.Initialized) {
       it("can transfer through Cryptid with a second key on the DID", async () => {
         const secondKey = Keypair.generate();
         await fund(secondKey.publicKey);

--- a/packages/tests/src/proposeExecute.ts
+++ b/packages/tests/src/proposeExecute.ts
@@ -12,8 +12,8 @@ import {
   makeTransfer,
   toAccountMeta,
 } from "./util/cryptid";
-import { initializeDIDAccount } from "./util/did";
-import { fund, createTestContext, balanceOf } from "./util/anchorUtils";
+import { getDidAccount, initializeDIDAccount } from "./util/did";
+import { fund, createTestContext, balanceOf, Wallet } from "./util/anchorUtils";
 import { DID_SOL_PROGRAM } from "@identity.com/sol-did-client";
 import { web3 } from "@project-serum/anchor";
 import {
@@ -25,285 +25,300 @@ import {
 chai.use(chaiAsPromised);
 const { expect } = chai;
 
-describe("proposeExecute", () => {
-  const { program, provider, authority, keypair } = createTestContext();
+const testCases = [
+  {
+    name: "generative",
+    beforeFn: async (authority: Wallet) => await getDidAccount(authority),
+  },
+  {
+    name: "non-generative",
+    beforeFn: async (authority: Wallet) =>
+      await initializeDIDAccount(authority),
+  },
+];
 
-  let didAccount: PublicKey;
-  let cryptidBump: number;
+testCases.forEach(({ name, beforeFn }) => {
+  describe(`proposeExecute (${name})`, () => {
+    const { program, provider, authority, keypair } = createTestContext();
 
-  const recipient = Keypair.generate();
+    let didAccount: PublicKey;
+    let cryptidBump: number;
 
-  let cryptid: CryptidClient;
+    const recipient = Keypair.generate();
 
-  // use this when testing directly against anchor
-  const transferInstructionData = cryptidTransferInstruction(LAMPORTS_PER_SOL); // 1 SOL
-  // use this when testing against the cryptid client
-  const makeTransaction = () =>
-    makeTransfer(cryptid.address(), recipient.publicKey);
+    let cryptid: CryptidClient;
 
-  const propose = async (
-    transactionAccount: Keypair,
-    instruction: InstructionData = transferInstructionData
-  ) =>
-    program.methods
-      .proposeTransaction([instruction], 2)
-      .accounts({
-        cryptidAccount: cryptid.address(),
-        owner: didAccount,
-        authority: authority.publicKey,
-        transactionAccount: transactionAccount.publicKey,
-      })
-      .remainingAccounts([
-        toAccountMeta(recipient.publicKey, true, false),
-        toAccountMeta(SystemProgram.programId),
-      ])
-      .signers([transactionAccount])
-      .rpc({ skipPreflight: true }); // skip preflight so we see validator logs on error
+    // use this when testing directly against anchor
+    const transferInstructionData =
+      cryptidTransferInstruction(LAMPORTS_PER_SOL); // 1 SOL
+    // use this when testing against the cryptid client
+    const makeTransaction = () =>
+      makeTransfer(cryptid.address(), recipient.publicKey);
 
-  const execute = (transactionAccount: Keypair) =>
-    // execute the Cryptid transaction
-    program.methods
-      .executeTransaction(
-        Buffer.from([]), // no controller chain,
-        cryptidBump,
-        0
-      )
-      .accounts({
-        cryptidAccount: cryptid.address(),
-        didProgram: DID_SOL_PROGRAM,
-        did: didAccount,
-        signer: authority.publicKey,
-        destination: authority.publicKey,
-        transactionAccount: transactionAccount.publicKey,
-      })
-      .remainingAccounts([
-        toAccountMeta(recipient.publicKey, true, false),
-        toAccountMeta(SystemProgram.programId),
-      ])
-      .rpc({ skipPreflight: true }); // skip preflight so we see validator logs on error
+    const propose = async (
+      transactionAccount: Keypair,
+      instruction: InstructionData = transferInstructionData
+    ) =>
+      program.methods
+        .proposeTransaction([instruction], 2)
+        .accounts({
+          cryptidAccount: cryptid.address(),
+          owner: didAccount,
+          authority: authority.publicKey,
+          transactionAccount: transactionAccount.publicKey,
+        })
+        .remainingAccounts([
+          toAccountMeta(recipient.publicKey, true, false),
+          toAccountMeta(SystemProgram.programId),
+        ])
+        .signers([transactionAccount])
+        .rpc({ skipPreflight: true }); // skip preflight so we see validator logs on error
 
-  before("Set up DID account", async () => {
-    await fund(authority.publicKey, 10 * LAMPORTS_PER_SOL);
-    didAccount = await initializeDIDAccount(authority);
-  });
+    const execute = (transactionAccount: Keypair) =>
+      // execute the Cryptid transaction
+      program.methods
+        .executeTransaction(
+          Buffer.from([]), // no controller chain,
+          cryptidBump,
+          0
+        )
+        .accounts({
+          cryptidAccount: cryptid.address(),
+          didProgram: DID_SOL_PROGRAM,
+          did: didAccount,
+          signer: authority.publicKey,
+          destination: authority.publicKey,
+          transactionAccount: transactionAccount.publicKey,
+        })
+        .remainingAccounts([
+          toAccountMeta(recipient.publicKey, true, false),
+          toAccountMeta(SystemProgram.programId),
+        ])
+        .rpc({ skipPreflight: true }); // skip preflight so we see validator logs on error
 
-  // TODO: Once the new anchor "default value" macro is available, switch this back to using a generative cryptid account
-  // For now, Propose/Execute requires non-generative accounts, so we can check for the presence of a registered middleware
-  before("Set up a Cryptid Account", async () => {
-    cryptid = await createCryptid(authority, {
-      connection: provider.connection,
+    before("Set up DID account", async () => {
+      await fund(authority.publicKey, 10 * LAMPORTS_PER_SOL);
+      didAccount = await beforeFn(authority);
     });
 
-    await fund(cryptid.address(), 20 * LAMPORTS_PER_SOL);
-  });
+    // TODO: Once the new anchor "default value" macro is available, switch this back to using a generative cryptid account
+    // For now, Propose/Execute requires non-generative accounts, so we can check for the presence of a registered middleware
+    before("Set up a Cryptid Account", async () => {
+      cryptid = await createCryptid(authority, {
+        connection: provider.connection,
+      });
 
-  it("can propose and execute a transfer through Cryptid", async () => {
-    const previousBalance = await balanceOf(cryptid.address());
+      await fund(cryptid.address(), 20 * LAMPORTS_PER_SOL);
+    });
 
-    const transactionAccount = Keypair.generate();
+    it("can propose and execute a transfer through Cryptid", async () => {
+      const previousBalance = await balanceOf(cryptid.address());
 
-    // propose the Cryptid transaction
-    await propose(transactionAccount);
+      const transactionAccount = Keypair.generate();
 
-    let currentBalance = await balanceOf(cryptid.address());
-    expect(previousBalance - currentBalance).to.equal(0); // Nothing has happened yet
+      // propose the Cryptid transaction
+      await propose(transactionAccount);
 
-    // execute the Cryptid transaction
-    await execute(transactionAccount);
+      let currentBalance = await balanceOf(cryptid.address());
+      expect(previousBalance - currentBalance).to.equal(0); // Nothing has happened yet
 
-    currentBalance = await balanceOf(cryptid.address());
-    expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed
-  });
+      // execute the Cryptid transaction
+      await execute(transactionAccount);
 
-  it("can propose and execute a transfer using the Cryptid client", async () => {
-    const previousBalance = await balanceOf(cryptid.address());
+      currentBalance = await balanceOf(cryptid.address());
+      expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed
+    });
 
-    // send the propose tx
-    const { proposeTransaction, transactionAccountAddress } =
-      await cryptid.propose(makeTransaction());
-    await cryptid.send(proposeTransaction, { skipPreflight: true });
+    it("can propose and execute a transfer using the Cryptid client", async () => {
+      const previousBalance = await balanceOf(cryptid.address());
 
-    let currentBalance = await balanceOf(cryptid.address());
-    expect(previousBalance - currentBalance).to.equal(0); // Nothing has happened yet
+      // send the propose tx
+      const { proposeTransaction, transactionAccountAddress } =
+        await cryptid.propose(makeTransaction());
+      await cryptid.send(proposeTransaction, { skipPreflight: true });
 
-    // send the execute tx
-    const [executeTransaction] = await cryptid.execute(
-      transactionAccountAddress
-    );
-    await cryptid.send(executeTransaction, { skipPreflight: true });
+      let currentBalance = await balanceOf(cryptid.address());
+      expect(previousBalance - currentBalance).to.equal(0); // Nothing has happened yet
 
-    currentBalance = await balanceOf(cryptid.address());
-    expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed
-  });
+      // send the execute tx
+      const [executeTransaction] = await cryptid.execute(
+        transactionAccountAddress
+      );
+      await cryptid.send(executeTransaction, { skipPreflight: true });
 
-  it("can propose and execute in the same transaction", async () => {
-    const previousBalance = await balanceOf(cryptid.address());
+      currentBalance = await balanceOf(cryptid.address());
+      expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed
+    });
 
-    const transactionAccount = Keypair.generate();
+    it("can propose and execute in the same transaction", async () => {
+      const previousBalance = await balanceOf(cryptid.address());
 
-    // propose the Cryptid transaction
-    const proposeIx = await program.methods
-      .proposeTransaction([transferInstructionData], 2)
-      .accounts({
-        cryptidAccount: cryptid.address(),
-        owner: didAccount,
-        authority: authority.publicKey,
-        transactionAccount: transactionAccount.publicKey,
-      })
-      .remainingAccounts([
-        toAccountMeta(recipient.publicKey, true, false),
-        toAccountMeta(SystemProgram.programId),
-      ])
-      .signers([transactionAccount])
-      .instruction();
+      const transactionAccount = Keypair.generate();
 
-    const executeIx = await program.methods
-      .executeTransaction(
-        Buffer.from([]), // no controller chain
-        cryptidBump,
-        0
-      )
-      .accounts({
-        cryptidAccount: cryptid.address(),
-        didProgram: DID_SOL_PROGRAM,
-        did: didAccount,
-        signer: authority.publicKey,
-        destination: authority.publicKey,
-        transactionAccount: transactionAccount.publicKey,
-      })
-      .remainingAccounts([
-        toAccountMeta(recipient.publicKey, true, false),
-        toAccountMeta(SystemProgram.programId),
-      ])
-      .instruction();
+      // propose the Cryptid transaction
+      const proposeIx = await program.methods
+        .proposeTransaction([transferInstructionData], 2)
+        .accounts({
+          cryptidAccount: cryptid.address(),
+          owner: didAccount,
+          authority: authority.publicKey,
+          transactionAccount: transactionAccount.publicKey,
+        })
+        .remainingAccounts([
+          toAccountMeta(recipient.publicKey, true, false),
+          toAccountMeta(SystemProgram.programId),
+        ])
+        .signers([transactionAccount])
+        .instruction();
 
-    const transaction = new web3.Transaction().add(proposeIx, executeIx);
+      const executeIx = await program.methods
+        .executeTransaction(
+          Buffer.from([]), // no controller chain
+          cryptidBump,
+          0
+        )
+        .accounts({
+          cryptidAccount: cryptid.address(),
+          didProgram: DID_SOL_PROGRAM,
+          did: didAccount,
+          signer: authority.publicKey,
+          destination: authority.publicKey,
+          transactionAccount: transactionAccount.publicKey,
+        })
+        .remainingAccounts([
+          toAccountMeta(recipient.publicKey, true, false),
+          toAccountMeta(SystemProgram.programId),
+        ])
+        .instruction();
 
-    await provider.sendAndConfirm(transaction, [keypair, transactionAccount]);
+      const transaction = new web3.Transaction().add(proposeIx, executeIx);
 
-    const currentBalance = await balanceOf(cryptid.address());
-    expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed
-  });
+      await provider.sendAndConfirm(transaction, [keypair, transactionAccount]);
 
-  it("can propose and execute in the same transaction using the cryptid client", async () => {
-    const previousBalance = await balanceOf(cryptid.address());
+      const currentBalance = await balanceOf(cryptid.address());
+      expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed
+    });
 
-    const [bigTransaction] = await cryptid.proposeAndExecute(
-      makeTransaction(),
-      true
-    );
-    await cryptid.send(bigTransaction, { skipPreflight: true });
+    it("can propose and execute in the same transaction using the cryptid client", async () => {
+      const previousBalance = await balanceOf(cryptid.address());
 
-    const currentBalance = await balanceOf(cryptid.address());
-    expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed
-  });
+      const [bigTransaction] = await cryptid.proposeAndExecute(
+        makeTransaction(),
+        true
+      );
+      await cryptid.send(bigTransaction, { skipPreflight: true });
 
-  it("can reuse the same transfer account", async () => {
-    const previousBalance = await balanceOf(cryptid.address());
+      const currentBalance = await balanceOf(cryptid.address());
+      expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed
+    });
 
-    const transactionAccount = Keypair.generate();
+    it("can reuse the same transfer account", async () => {
+      const previousBalance = await balanceOf(cryptid.address());
 
-    // Propose & execute once
-    await propose(transactionAccount);
-    await execute(transactionAccount);
+      const transactionAccount = Keypair.generate();
 
-    // Propose & execute twice
-    await propose(transactionAccount);
-    await execute(transactionAccount);
+      // Propose & execute once
+      await propose(transactionAccount);
+      await execute(transactionAccount);
 
-    const currentBalance = await balanceOf(cryptid.address());
+      // Propose & execute twice
+      await propose(transactionAccount);
+      await execute(transactionAccount);
 
-    // The tx has been executed twice
-    // Note - this is not a double-spend, as the tx has to be proposed twice
-    expect(previousBalance - currentBalance).to.equal(2 * LAMPORTS_PER_SOL);
-  });
+      const currentBalance = await balanceOf(cryptid.address());
 
-  it("cannot re-execute the same proposed transfer", async () => {
-    const previousBalance = await balanceOf(cryptid.address());
+      // The tx has been executed twice
+      // Note - this is not a double-spend, as the tx has to be proposed twice
+      expect(previousBalance - currentBalance).to.equal(2 * LAMPORTS_PER_SOL);
+    });
 
-    const transactionAccount = Keypair.generate();
+    it("cannot re-execute the same proposed transfer", async () => {
+      const previousBalance = await balanceOf(cryptid.address());
 
-    // Propose & execute
-    await propose(transactionAccount);
-    await execute(transactionAccount);
+      const transactionAccount = Keypair.generate();
 
-    // cannot re-execute
-    const shouldFail = execute(transactionAccount);
+      // Propose & execute
+      await propose(transactionAccount);
+      await execute(transactionAccount);
 
-    const currentBalance = await balanceOf(cryptid.address());
+      // cannot re-execute
+      const shouldFail = execute(transactionAccount);
 
-    // The tx has been executed once only
-    expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL);
+      const currentBalance = await balanceOf(cryptid.address());
 
-    // TODO expose the error message
-    return expect(shouldFail).to.be.rejected;
-  });
+      // The tx has been executed once only
+      expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL);
 
-  it("rejects the execution if the cryptid account is not a signer", async () => {
-    const transactionAccount = Keypair.generate();
+      // TODO expose the error message
+      return expect(shouldFail).to.be.rejected;
+    });
 
-    const instructionDataWithUnauthorisedSigner =
-      cryptidTransferInstruction(LAMPORTS_PER_SOL); // 1 SOL
-    // set the cryptid account as a non-signer on the transfer
-    (
-      instructionDataWithUnauthorisedSigner.accounts as TransactionAccountMeta[]
-    )[0].meta = 2; // writable but not a signer
+    it("rejects the execution if the cryptid account is not a signer", async () => {
+      const transactionAccount = Keypair.generate();
 
-    await propose(transactionAccount, instructionDataWithUnauthorisedSigner);
-    const shouldFail = execute(transactionAccount);
+      const instructionDataWithUnauthorisedSigner =
+        cryptidTransferInstruction(LAMPORTS_PER_SOL); // 1 SOL
+      // set the cryptid account as a non-signer on the transfer
+      (
+        instructionDataWithUnauthorisedSigner.accounts as TransactionAccountMeta[]
+      )[0].meta = 2; // writable but not a signer
 
-    // TODO expose the error message
-    return expect(shouldFail).to.be.rejected;
-  });
+      await propose(transactionAccount, instructionDataWithUnauthorisedSigner);
+      const shouldFail = execute(transactionAccount);
 
-  it("rejects the execution if the recipient account index is invalid", async () => {
-    const transactionAccount = Keypair.generate();
+      // TODO expose the error message
+      return expect(shouldFail).to.be.rejected;
+    });
 
-    const instructionDataWithInvalidAccountIndex =
-      cryptidTransferInstruction(LAMPORTS_PER_SOL); // 1 SOL
-    // set the recipient account as an invalid account index
-    (
-      instructionDataWithInvalidAccountIndex.accounts as TransactionAccountMeta[]
-    )[1].key = 100; // account 100 does not exist
+    it("rejects the execution if the recipient account index is invalid", async () => {
+      const transactionAccount = Keypair.generate();
 
-    // TODO this should fail on propose
-    await propose(transactionAccount, instructionDataWithInvalidAccountIndex);
-    const shouldFail = execute(transactionAccount);
+      const instructionDataWithInvalidAccountIndex =
+        cryptidTransferInstruction(LAMPORTS_PER_SOL); // 1 SOL
+      // set the recipient account as an invalid account index
+      (
+        instructionDataWithInvalidAccountIndex.accounts as TransactionAccountMeta[]
+      )[1].key = 100; // account 100 does not exist
 
-    return expect(shouldFail).to.be.rejectedWith(/ProgramFailedToComplete/);
-  });
+      // TODO this should fail on propose
+      await propose(transactionAccount, instructionDataWithInvalidAccountIndex);
+      const shouldFail = execute(transactionAccount);
 
-  it("rejects the transfer if the signer is not a valid signer on the DID", async () => {
-    const transactionAccount = Keypair.generate();
+      return expect(shouldFail).to.be.rejectedWith(/ProgramFailedToComplete/);
+    });
 
-    const bogusSigner = Keypair.generate();
+    it("rejects the transfer if the signer is not a valid signer on the DID", async () => {
+      const transactionAccount = Keypair.generate();
 
-    await propose(transactionAccount);
-    // execute the Cryptid transaction
-    const shouldFail = program.methods
-      .executeTransaction(
-        Buffer.from([]), // no controller chain
-        cryptidBump,
-        0
-      )
-      .accounts({
-        cryptidAccount: cryptid.address(),
-        didProgram: DID_SOL_PROGRAM,
-        did: didAccount,
-        signer: bogusSigner.publicKey, // specify the bogus signer as the cryptid signer
-        destination: authority.publicKey,
-        transactionAccount: transactionAccount.publicKey,
-      })
-      .remainingAccounts([
-        toAccountMeta(recipient.publicKey, true, false),
-        toAccountMeta(SystemProgram.programId),
-      ])
-      .signers(
-        [bogusSigner] // sign with the bogus signer
-      )
-      .rpc({ skipPreflight: true }); // skip preflight so we see validator logs on error
+      const bogusSigner = Keypair.generate();
 
-    // TODO expose the error from the program
-    return expect(shouldFail).to.be.rejected;
+      await propose(transactionAccount);
+      // execute the Cryptid transaction
+      const shouldFail = program.methods
+        .executeTransaction(
+          Buffer.from([]), // no controller chain
+          cryptidBump,
+          0
+        )
+        .accounts({
+          cryptidAccount: cryptid.address(),
+          didProgram: DID_SOL_PROGRAM,
+          did: didAccount,
+          signer: bogusSigner.publicKey, // specify the bogus signer as the cryptid signer
+          destination: authority.publicKey,
+          transactionAccount: transactionAccount.publicKey,
+        })
+        .remainingAccounts([
+          toAccountMeta(recipient.publicKey, true, false),
+          toAccountMeta(SystemProgram.programId),
+        ])
+        .signers(
+          [bogusSigner] // sign with the bogus signer
+        )
+        .rpc({ skipPreflight: true }); // skip preflight so we see validator logs on error
+
+      // TODO expose the error from the program
+      return expect(shouldFail).to.be.rejected;
+    });
   });
 });

--- a/packages/tests/src/proposeExecute.ts
+++ b/packages/tests/src/proposeExecute.ts
@@ -12,8 +12,8 @@ import {
   makeTransfer,
   toAccountMeta,
 } from "./util/cryptid";
-import { getDidAccount, initializeDIDAccount } from "./util/did";
-import { fund, createTestContext, balanceOf, Wallet } from "./util/anchorUtils";
+import { didTestCases } from "./util/did";
+import { fund, createTestContext, balanceOf } from "./util/anchorUtils";
 import { DID_SOL_PROGRAM } from "@identity.com/sol-did-client";
 import { web3 } from "@project-serum/anchor";
 import {
@@ -25,20 +25,8 @@ import {
 chai.use(chaiAsPromised);
 const { expect } = chai;
 
-const testCases = [
-  {
-    name: "generative",
-    beforeFn: async (authority: Wallet) => await getDidAccount(authority),
-  },
-  {
-    name: "non-generative",
-    beforeFn: async (authority: Wallet) =>
-      await initializeDIDAccount(authority),
-  },
-];
-
-testCases.forEach(({ name, beforeFn }) => {
-  describe(`proposeExecute (${name})`, () => {
+didTestCases.forEach(({ type, beforeFn }) => {
+  describe(`proposeExecute (${type})`, () => {
     const { program, provider, authority, keypair } = createTestContext();
 
     let didAccount: PublicKey;

--- a/packages/tests/src/util/did.ts
+++ b/packages/tests/src/util/did.ts
@@ -39,3 +39,20 @@ export const getDidAccount = async (authority: Wallet): Promise<PublicKey> => {
   const did = DidSolIdentifier.create(authority.publicKey, CLUSTER);
   return did.dataAccount()[0];
 };
+
+export enum DidTestType {
+  Generative = "generative DID",
+  Initialized = "initialized DID",
+}
+
+export const didTestCases = [
+  {
+    type: DidTestType.Generative,
+    beforeFn: async (authority: Wallet) => await getDidAccount(authority),
+  },
+  {
+    type: DidTestType.Initialized,
+    beforeFn: async (authority: Wallet) =>
+      await initializeDIDAccount(authority),
+  },
+];

--- a/packages/tests/src/util/did.ts
+++ b/packages/tests/src/util/did.ts
@@ -34,3 +34,8 @@ export const initializeDIDAccount = async (
   await didSolService.initialize(10_000).rpc();
   return did.dataAccount()[0];
 };
+
+export const getDidAccount = async (authority: Wallet): Promise<PublicKey> => {
+  const did = DidSolIdentifier.create(authority.publicKey, CLUSTER);
+  return did.dataAccount()[0];
+};

--- a/programs/cryptid/src/instructions/create.rs
+++ b/programs/cryptid/src/instructions/create.rs
@@ -3,7 +3,6 @@ use crate::instructions::util::*;
 use crate::state::cryptid_account::CryptidAccount;
 use crate::util::*;
 use anchor_lang::prelude::*;
-use sol_did::state::DidAccount;
 
 #[derive(Accounts)]
 #[instruction(
@@ -26,7 +25,8 @@ pub struct Create<'info> {
     /// The program for the DID
     pub did_program: Program<'info, SolDID>,
     /// The DID of the Cryptid instance
-    pub did: Account<'info, DidAccount>,
+    /// CHECK: DID Account can be generative or not
+    pub did: UncheckedAccount<'info>,
     /// The signer of the transaction. Must be a DID authority.
     #[account(mut)]
     pub authority: Signer<'info>,

--- a/programs/cryptid/src/instructions/create.rs
+++ b/programs/cryptid/src/instructions/create.rs
@@ -24,7 +24,7 @@ pub struct Create<'info> {
     pub cryptid_account: Account<'info, CryptidAccount>,
     /// The program for the DID
     pub did_program: Program<'info, SolDID>,
-    /// The DID of the Cryptid instance
+    /// The DID on the Cryptid instance
     /// CHECK: DID Account can be generative or not
     pub did: UncheckedAccount<'info>,
     /// The signer of the transaction. Must be a DID authority.

--- a/programs/cryptid/src/instructions/direct_execute.rs
+++ b/programs/cryptid/src/instructions/direct_execute.rs
@@ -26,7 +26,7 @@ pub struct DirectExecute<'info> {
         // bump = cryptid_account_bump
     )]
     pub cryptid_account: UncheckedAccount<'info>, // TODO use new macro that allows generative accounts and non-generative accounts
-    /// The DID of the Cryptid instance
+    /// The DID on the Cryptid instance
     /// CHECK: DID Account can be generative or not
     pub did: UncheckedAccount<'info>,
     /// The program for the DID

--- a/programs/cryptid/src/instructions/direct_execute.rs
+++ b/programs/cryptid/src/instructions/direct_execute.rs
@@ -4,7 +4,6 @@ use crate::state::cryptid_account::CryptidAccount;
 use crate::util::cpi::CPI;
 use crate::util::*;
 use anchor_lang::prelude::*;
-use sol_did::state::DidAccount;
 
 #[derive(Accounts)]
 #[instruction(
@@ -27,8 +26,9 @@ pub struct DirectExecute<'info> {
         // bump = cryptid_account_bump
     )]
     pub cryptid_account: UncheckedAccount<'info>, // TODO use new macro that allows generative accounts and non-generative accounts
-    /// The DID on the Cryptid instance
-    pub did: Account<'info, DidAccount>,
+    /// The DID of the Cryptid instance
+    /// CHECK: DID Account can be generative or not
+    pub did: UncheckedAccount<'info>,
     /// The program for the DID
     pub did_program: Program<'info, SolDID>,
     /// The signer of the transaction

--- a/programs/cryptid/src/instructions/execute_transaction.rs
+++ b/programs/cryptid/src/instructions/execute_transaction.rs
@@ -25,7 +25,7 @@ pub struct ExecuteTransaction<'info> {
         bump
     )]
     pub cryptid_account: Account<'info, CryptidAccount>, // TODO use new macro that allows generative accounts
-    /// The DID of the Cryptid instance
+    /// The DID on the Cryptid instance
     /// CHECK: DID Account can be generative or not
     pub did: UncheckedAccount<'info>,
     /// The program for the DID

--- a/programs/cryptid/src/instructions/execute_transaction.rs
+++ b/programs/cryptid/src/instructions/execute_transaction.rs
@@ -6,7 +6,6 @@ use crate::state::transaction_state::TransactionState;
 use crate::util::cpi::*;
 use crate::util::*;
 use anchor_lang::prelude::*;
-use sol_did::state::DidAccount;
 
 #[derive(Accounts)]
 #[instruction(
@@ -26,8 +25,9 @@ pub struct ExecuteTransaction<'info> {
         bump
     )]
     pub cryptid_account: Account<'info, CryptidAccount>, // TODO use new macro that allows generative accounts
-    /// The DID on the Cryptid instance
-    pub did: Account<'info, DidAccount>,
+    /// The DID of the Cryptid instance
+    /// CHECK: DID Account can be generative or not
+    pub did: UncheckedAccount<'info>,
     /// The program for the DID
     pub did_program: Program<'info, SolDID>,
     /// The signer of the transaction

--- a/programs/cryptid/src/instructions/util.rs
+++ b/programs/cryptid/src/instructions/util.rs
@@ -2,7 +2,6 @@ use crate::error::CryptidError;
 use anchor_lang::prelude::*;
 use bitflags::bitflags;
 use num_traits::cast::ToPrimitive;
-use sol_did::state::DidAccount;
 
 /// A trait that extracts all accounts from an anchor instruction context, combining
 pub trait AllAccounts<'a, 'b, 'c, 'info> {
@@ -48,17 +47,17 @@ impl<T: AccountSerialize + AccountDeserialize + Owner + Clone> IsGenerative<T> f
 /// Verifies that the signer has the permission to sign for the DID
 /// If the controller-chain is empty, it expects the signer to be a key on the did itself
 /// Otherwise, the signer is a signer on a controller of the DID (either directly or indirectly)
-pub fn verify_keys<'a, 'info>(
-    did: &Account<'a, DidAccount>,
+pub fn verify_keys<'info1, 'info2>(
+    did: &AccountInfo<'info1>,
     signer: &Pubkey,
-    controlling_did_accounts: Vec<&AccountInfo<'info>>,
+    controlling_did_accounts: Vec<&AccountInfo<'info2>>,
 ) -> Result<()> {
     let controlling_did_accounts = controlling_did_accounts
         .into_iter()
         .cloned()
         .collect::<Vec<_>>();
     let signer_is_authority = sol_did::integrations::is_authority(
-        &did.to_account_info(),
+        did,
         None,
         controlling_did_accounts.as_slice(),
         signer,

--- a/programs/middleware/check_pass/src/lib.rs
+++ b/programs/middleware/check_pass/src/lib.rs
@@ -7,7 +7,6 @@ use cryptid::error::CryptidError;
 use cryptid::program::Cryptid;
 use cryptid::state::transaction_account::TransactionAccount;
 use num_traits::cast::AsPrimitive;
-use sol_did::state::DidAccount;
 use solana_gateway::{instruction::expire_token, state::GatewayToken, Gateway};
 use std::str::FromStr;
 
@@ -182,8 +181,9 @@ pub struct ExecuteMiddleware<'info> {
     /// The owner of the Cryptid instance, typically a DID account
     /// Passed here so that the DID document can be parsed.
     /// The gateway token can be on any key provably owned by the DID.
+    /// CHECK: DID Account can be generative or not
     #[account()]
-    pub owner: Account<'info, DidAccount>, // TODO allow generative/non-generative
+    pub owner: UncheckedAccount<'info>,
     /// An authority on the DID.
     /// This is needed for two cases:
     /// 1) the expireOnUse case. In this case, the authority must be the owner of the gateway token.


### PR DESCRIPTION
- Main Test-cases were adapted to run twice, one for a generative and one time for a persisted DID.
- Middleware tests were NOT adapted (yet) to run with any generative cases. (discuss how much we want to blow up the tests).
- This approach will not work if anything but is_authority should be triggered on the DID.