### PR TITLE
Security Feedback Integration

### DIFF
--- a/packages/client/cli/README.md
+++ b/packages/client/cli/README.md
@@ -20,7 +20,7 @@ $ npm install -g @identity.com/cryptid-cli
 $ cryptid COMMAND
 running command...
 $ cryptid (--version)
-@identity.com/cryptid-cli/0.3.0-alpha.9 darwin-arm64 node-v16.15.1
+@identity.com/cryptid-cli/0.3.0-alpha.9 darwin-arm64 node-v16.13.0
 $ cryptid --help [COMMAND]
 USAGE
   $ cryptid COMMAND
@@ -29,7 +29,7 @@ USAGE
 <!-- usagestop -->
 # Commands
 <!-- commands -->
-* [`cryptid [DID]`](#cryptid-did)
+* [`cryptid`](#cryptid)
 * [`cryptid accounts`](#cryptid-accounts)
 * [`cryptid accounts set INDEX`](#cryptid-accounts-set-index)
 * [`cryptid address`](#cryptid-address)
@@ -39,9 +39,7 @@ USAGE
 * [`cryptid base`](#cryptid-base)
 * [`cryptid config`](#cryptid-config)
 * [`cryptid config set [KEY] [VALUE]`](#cryptid-config-set-key-value)
-* [`cryptid config show`](#cryptid-config-show)
 * [`cryptid controller [DID]`](#cryptid-controller-did)
-* [`cryptid controller show [DID]`](#cryptid-controller-show-did)
 * [`cryptid document`](#cryptid-document)
 * [`cryptid help [COMMAND]`](#cryptid-help-command)
 * [`cryptid init`](#cryptid-init)
@@ -63,13 +61,13 @@ USAGE
 * [`cryptid token transfer TO AMOUNT`](#cryptid-token-transfer-to-amount)
 * [`cryptid transfer TO AMOUNT`](#cryptid-transfer-to-amount)
 
-## `cryptid [DID]`
+## `cryptid`
 
-Show the controllers of a cryptid account
+List keys attached to the cryptid account
 
 ```
 USAGE
-  $ cryptid [DID] [-h] [-c <value>] [-s <value>]
+  $ cryptid [-h] [-c <value>] [-s <value>]
 
 FLAGS
   -c, --config=<value>  Path to config file
@@ -77,7 +75,7 @@ FLAGS
   -s, --as=<value>      Execute transactions as a controlled identity (alias or did)
 
 DESCRIPTION
-  Show the controllers of a cryptid account
+  List keys attached to the cryptid account
 
 ALIASES
   $ cryptid
@@ -252,23 +250,6 @@ DESCRIPTION
   Set a Cryptid configuration value
 ```
 
-## `cryptid config show`
-
-Show Cryptid configuration
-
-```
-USAGE
-  $ cryptid config show [-h] [-c <value>] [-s <value>]
-
-FLAGS
-  -c, --config=<value>  Path to config file
-  -h, --help            Show CLI help.
-  -s, --as=<value>      Execute transactions as a controlled identity (alias or did)
-
-DESCRIPTION
-  Show Cryptid configuration
-```
-
 ## `cryptid controller [DID]`
 
 Show the controllers of a cryptid account
@@ -290,26 +271,6 @@ ALIASES
 ```
 
 _See code: [dist/commands/controller/index.ts](https://github.com/identity-com/cryptid/blob/v0.3.0-alpha.9/dist/commands/controller/index.ts)_
-
-## `cryptid controller show [DID]`
-
-Show the controllers of a cryptid account
-
-```
-USAGE
-  $ cryptid controller show [DID] [-h] [-c <value>] [-s <value>]
-
-FLAGS
-  -c, --config=<value>  Path to config file
-  -h, --help            Show CLI help.
-  -s, --as=<value>      Execute transactions as a controlled identity (alias or did)
-
-DESCRIPTION
-  Show the controllers of a cryptid account
-
-ALIASES
-  $ cryptid
-```
 
 ## `cryptid document`
 

--- a/packages/client/cli/src/service/cryptid/index.ts
+++ b/packages/client/cli/src/service/cryptid/index.ts
@@ -121,9 +121,9 @@ const createCryptidTransaction = async (
   transaction: Transaction
 ): Promise<[Transaction[], Signer[]]> => {
   if (cryptid.details.middlewares.length) {
-    const { proposeExecuteTransactions, transactionAccount } =
+    const { proposeExecuteTransactions, signers } =
       await cryptid.proposeAndExecute(transaction);
-    return [proposeExecuteTransactions, [transactionAccount]];
+    return [proposeExecuteTransactions, signers];
   } else {
     return [await cryptid.directExecute(transaction).then((tx) => [tx]), []];
   }

--- a/packages/client/core/src/api/abstractCryptidClient.ts
+++ b/packages/client/core/src/api/abstractCryptidClient.ts
@@ -80,15 +80,14 @@ export abstract class AbstractCryptidClient implements CryptidClient {
         proposeExecuteTransactions: [
           proposeExecuteTransaction.proposeExecuteTransaction,
         ],
-        transactionAccount: proposeExecuteTransaction.transactionAccount,
+        signers: proposeExecuteTransaction.signers,
       };
     }
 
     const proposalResult = await service.propose(this.details, transaction);
     const executeTransaction = await service.execute(
       this.details,
-      proposalResult.transactionAccount.publicKey,
-      [],
+      proposalResult.transactionAccount,
       proposalResult.cryptidTransactionRepresentation
     );
 
@@ -97,7 +96,7 @@ export abstract class AbstractCryptidClient implements CryptidClient {
         proposalResult.proposeTransaction,
         executeTransaction,
       ],
-      transactionAccount: proposalResult.transactionAccount,
+      signers: proposalResult.signers,
     };
   }
 

--- a/packages/client/core/src/api/cryptidBuilder.ts
+++ b/packages/client/core/src/api/cryptidBuilder.ts
@@ -59,13 +59,14 @@ export class CryptidBuilder {
   ): Promise<CryptidClient> {
     const index = options.accountIndex === undefined ? 1 : options.accountIndex; // 0 is reserved for the default (generative) cryptid
     const didAccount = didToPDA(did);
-    const [address, bump] = getCryptidAccountAddress(didAccount, index);
+    const [address, bump] = getCryptidAccountAddress(didAccount[0], index);
     const details = new CryptidAccountDetails(
       address,
       bump,
       index,
       did,
-      didAccount,
+      didAccount[0],
+      didAccount[1],
       middleware
     );
     return CryptidBuilder.create(details, signer, options);

--- a/packages/client/core/src/api/cryptidClient.ts
+++ b/packages/client/core/src/api/cryptidClient.ts
@@ -2,6 +2,7 @@ import {
   ConfirmOptions,
   Connection,
   PublicKey,
+  Signer,
   Transaction,
   TransactionSignature,
 } from "@solana/web3.js";
@@ -10,6 +11,7 @@ import { Wallet } from "../types/crypto";
 import { ProposalResult, TransactionAccount } from "../types";
 import { CryptidAccountDetails } from "../lib/CryptidAccountDetails";
 import { Middleware } from "../lib/Middleware";
+import { ProposeExecuteArrayResult } from "../types/cryptid";
 
 export type PayerOption = "DID_PAYS" | "SIGNER_PAYS";
 export type CryptidOptions = {
@@ -85,7 +87,7 @@ export interface CryptidClient {
   proposeAndExecute(
     transaction: Transaction,
     forceSingleTx?: boolean
-  ): Promise<Transaction[]>;
+  ): Promise<ProposeExecuteArrayResult>;
 
   propose(transaction: Transaction): Promise<ProposalResult>;
   execute(transactionAccountAddress: PublicKey): Promise<Transaction[]>;
@@ -114,6 +116,7 @@ export interface CryptidClient {
 
   send(
     transaction: Transaction,
+    signers?: Signer[],
     confirmOptions?: ConfirmOptions
   ): Promise<TransactionSignature>;
 }

--- a/packages/client/core/src/api/cryptidClient.ts
+++ b/packages/client/core/src/api/cryptidClient.ts
@@ -11,7 +11,7 @@ import { Wallet } from "../types/crypto";
 import { ProposalResult, TransactionAccount } from "../types";
 import { CryptidAccountDetails } from "../lib/CryptidAccountDetails";
 import { Middleware } from "../lib/Middleware";
-import { ProposeExecuteArrayResult } from "../types/cryptid";
+import { ExecuteArrayResult } from "../types/cryptid";
 
 export type PayerOption = "DID_PAYS" | "SIGNER_PAYS";
 export type CryptidOptions = {
@@ -87,10 +87,10 @@ export interface CryptidClient {
   proposeAndExecute(
     transaction: Transaction,
     forceSingleTx?: boolean
-  ): Promise<ProposeExecuteArrayResult>;
+  ): Promise<ExecuteArrayResult>;
 
   propose(transaction: Transaction): Promise<ProposalResult>;
-  execute(transactionAccountAddress: PublicKey): Promise<Transaction[]>;
+  execute(transactionAccountAddress: PublicKey): Promise<ExecuteArrayResult>;
 
   // TODO Reinstate
   // cancelLarge(transactionAccount: PublicKey): Promise<TransactionSignature>;

--- a/packages/client/core/src/lib/CryptidAccountDetails.ts
+++ b/packages/client/core/src/lib/CryptidAccountDetails.ts
@@ -16,6 +16,8 @@ export class CryptidAccountDetails {
     readonly ownerDID: string,
     // The on-chain PDA of the DID (may be generative)
     readonly didAccount: PublicKey,
+    // The correct bump for the given didAccount
+    readonly didAccountBump: number,
     // Middlewares attached to the account
     readonly middlewares: Middleware[]
   ) {}
@@ -30,13 +32,14 @@ export class CryptidAccountDetails {
     middlewares: Middleware[] = []
   ): CryptidAccountDetails {
     const didAccount = didToPDA(did);
-    const [address, bump] = getCryptidAccountAddress(didAccount, index);
+    const [address, bump] = getCryptidAccountAddress(didAccount[0], index);
     return new CryptidAccountDetails(
       address,
       bump,
       index,
       did,
-      didAccount,
+      didAccount[0],
+      didAccount[1],
       middlewares
     );
   }
@@ -51,13 +54,17 @@ export class CryptidAccountDetails {
     // TODO optimise? this is literally just to recalculate the bump
     // NOTE: the bump is needed when making transactions.
     // It is not stored on the cryptid account, as that does not work with the generative case.
-    const [, bump] = getCryptidAccountAddress(didAccount, cryptidAccount.index);
+    const [, bump] = getCryptidAccountAddress(
+      didAccount[0],
+      cryptidAccount.index
+    );
     return new CryptidAccountDetails(
       address,
       bump,
       cryptidAccount.index,
       did,
-      didAccount,
+      didAccount[0],
+      didAccount[1],
       middlewareAccounts.map(
         ([key, accountInfo]) => new Middleware(accountInfo.owner, key)
       )

--- a/packages/client/core/src/lib/CryptidTransaction.ts
+++ b/packages/client/core/src/lib/CryptidTransaction.ts
@@ -148,6 +148,7 @@ export class CryptidTransaction {
       .executeTransaction(
         Buffer.from([]), // TODO, support controller chain,
         this.cryptidAccount.bump,
+        this.cryptidAccount.index,
         this.cryptidAccount.didAccountBump,
         0
       )

--- a/packages/client/core/src/lib/CryptidTransaction.ts
+++ b/packages/client/core/src/lib/CryptidTransaction.ts
@@ -133,7 +133,7 @@ export class CryptidTransaction {
       .proposeTransaction(this.instructions, this.accountMetas.length)
       .accounts({
         cryptidAccount: this.cryptidAccount.address,
-        owner: this.cryptidAccount.didAccount,
+        did: this.cryptidAccount.didAccount,
         authority: this.authority,
         transactionAccount: transactionAccountAddress,
       })

--- a/packages/client/core/src/lib/CryptidTransaction.ts
+++ b/packages/client/core/src/lib/CryptidTransaction.ts
@@ -148,6 +148,7 @@ export class CryptidTransaction {
       .executeTransaction(
         Buffer.from([]), // TODO, support controller chain,
         this.cryptidAccount.bump,
+        this.cryptidAccount.didAccountBump,
         0
       )
       .accounts({
@@ -169,7 +170,8 @@ export class CryptidTransaction {
         Buffer.from([]), // TODO, support controller chain,
         this.instructions,
         this.cryptidAccount.bump,
-        this.cryptidAccount.index
+        this.cryptidAccount.didAccountBump,
+        this.cryptidAccount.index // TODO FIX: That is the flag, not the index.
       )
       .accounts({
         cryptidAccount: this.cryptidAccount.address,

--- a/packages/client/core/src/lib/CryptidTransaction.ts
+++ b/packages/client/core/src/lib/CryptidTransaction.ts
@@ -132,6 +132,8 @@ export class CryptidTransaction {
     return program.methods
       .proposeTransaction(
         Buffer.from([]), // TODO, support controller chain,
+        this.cryptidAccount.bump,
+        this.cryptidAccount.index,
         this.cryptidAccount.didAccountBump,
         this.instructions,
         this.accountMetas.length

--- a/packages/client/core/src/lib/CryptidTransaction.ts
+++ b/packages/client/core/src/lib/CryptidTransaction.ts
@@ -130,9 +130,15 @@ export class CryptidTransaction {
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   propose(program: Program<Cryptid>, transactionAccountAddress: PublicKey) {
     return program.methods
-      .proposeTransaction(this.instructions, this.accountMetas.length)
+      .proposeTransaction(
+        Buffer.from([]), // TODO, support controller chain,
+        this.cryptidAccount.didAccountBump,
+        this.instructions,
+        this.accountMetas.length
+      )
       .accounts({
         cryptidAccount: this.cryptidAccount.address,
+        didProgram: DID_SOL_PROGRAM,
         did: this.cryptidAccount.didAccount,
         authority: this.authority,
         transactionAccount: transactionAccountAddress,

--- a/packages/client/core/src/lib/CryptidTransaction.ts
+++ b/packages/client/core/src/lib/CryptidTransaction.ts
@@ -170,8 +170,9 @@ export class CryptidTransaction {
         Buffer.from([]), // TODO, support controller chain,
         this.instructions,
         this.cryptidAccount.bump,
+        this.cryptidAccount.index,
         this.cryptidAccount.didAccountBump,
-        this.cryptidAccount.index // TODO FIX: That is the flag, not the index.
+        0
       )
       .accounts({
         cryptidAccount: this.cryptidAccount.address,

--- a/packages/client/core/src/lib/cryptid.ts
+++ b/packages/client/core/src/lib/cryptid.ts
@@ -155,26 +155,30 @@ export const getCryptidAccountAddress = (
 export const getCryptidAccountAddressFromDID = (
   did: string,
   index = 0
-): [PublicKey, number] => getCryptidAccountAddress(didToPDA(did), index);
+): [PublicKey, number] => getCryptidAccountAddress(didToPDA(did)[0], index);
 
 export const createCryptidAccount = async (
   program: Program<Cryptid>,
-  did: PublicKey,
+  didAccount: PublicKey,
+  didAccountBump: number,
   middlewareAccount?: PublicKey,
   index = 0
 ): Promise<[PublicKey, number]> => {
-  const [cryptidAccount, cryptidBump] = getCryptidAccountAddress(did, index);
+  const [cryptidAccount, cryptidBump] = getCryptidAccountAddress(
+    didAccount,
+    index
+  );
 
   await program.methods
     .create(
       middlewareAccount || null, // anchor requires null instead of undefined
       index,
-      cryptidBump
+      didAccountBump
     )
     .accounts({
       cryptidAccount,
       didProgram: DID_SOL_PROGRAM,
-      did,
+      did: didAccount,
       authority: program.provider.publicKey,
     })
     .rpc({ skipPreflight: true });

--- a/packages/client/core/src/lib/did.ts
+++ b/packages/client/core/src/lib/did.ts
@@ -17,5 +17,5 @@ export const didService = (
 export const didToPublicKey = (did: string): PublicKey =>
   DidSolIdentifier.parse(did).authority;
 
-export const didToPDA = (did: string): PublicKey =>
-  DidSolIdentifier.parse(did).dataAccount()[0];
+export const didToPDA = (did: string): [PublicKey, number] =>
+  DidSolIdentifier.parse(did).dataAccount();

--- a/packages/client/core/src/service/cryptid.ts
+++ b/packages/client/core/src/service/cryptid.ts
@@ -321,8 +321,6 @@ export class CryptidService {
       this.authorityKey,
       transaction.instructions
     );
-    return await cryptidTransaction
-      .directExecute(this.program)
-      .transaction();
+    return await cryptidTransaction.directExecute(this.program).transaction();
   }
 }

--- a/packages/client/core/src/service/cryptid.ts
+++ b/packages/client/core/src/service/cryptid.ts
@@ -5,7 +5,6 @@ import {
   Keypair,
   PublicKey,
   Transaction,
-  TransactionInstruction,
 } from "@solana/web3.js";
 import { Wallet } from "../types/crypto";
 import { AnchorProvider, parseIdlErrors, Program } from "@project-serum/anchor";
@@ -24,7 +23,8 @@ import { range } from "ramda";
 import { didToPDA } from "../lib/did";
 import { DID_SOL_PROGRAM } from "@identity.com/sol-did-client";
 import { MiddlewareRegistry } from "./middlewareRegistry";
-import { ProposeExecuteResult, ProposalResult } from "../types/cryptid";
+import { ExecuteResult, ProposalResult } from "../types/cryptid";
+import { MiddlewareResult } from "../types/middleware";
 
 export class CryptidService {
   readonly program: Program<Cryptid>;
@@ -158,7 +158,7 @@ export class CryptidService {
     account: CryptidAccountDetails,
     transactionAccount: PublicKey,
     stage: "Propose" | "Execute"
-  ): Promise<TransactionInstruction[]> {
+  ): Promise<MiddlewareResult> {
     const middlewareContexts =
       MiddlewareRegistry.get().getMiddlewareContexts(account);
     const executeParameters: Omit<
@@ -181,7 +181,16 @@ export class CryptidService {
           middlewareAccount: accounts.address,
         })
       )
-    ).then((instructions) => instructions.flat());
+    ).then((results) =>
+      // Flatten into single MiddlewareResult
+      results.reduce(
+        (acc, currentValue) => ({
+          instructions: acc.instructions.concat(currentValue.instructions),
+          signers: acc.signers.concat(currentValue.signers),
+        }),
+        { instructions: [], signers: [] }
+      )
+    );
   }
 
   private async getCryptidTransaction(
@@ -213,7 +222,7 @@ export class CryptidService {
       transaction.instructions
     );
 
-    const middlewareInstructions = await this.executeMiddlewareInstructions(
+    const middlewareResult = await this.executeMiddlewareInstructions(
       account,
       transactionAccountKeypair.publicKey,
       "Propose"
@@ -225,13 +234,14 @@ export class CryptidService {
         // The only signer in a proposal (other than an authority on the DID) is the transaction account
         [transactionAccountKeypair]
       )
-      .postInstructions(middlewareInstructions)
+      .postInstructions(middlewareResult.instructions)
+      .signers(middlewareResult.signers)
       .transaction();
 
     return {
       proposeTransaction: unsignedProposeTransaction,
       transactionAccount: transactionAccountKeypair.publicKey,
-      signers: [transactionAccountKeypair],
+      proposeSigners: [transactionAccountKeypair, ...middlewareResult.signers],
       cryptidTransactionRepresentation: cryptidTransaction,
     };
   }
@@ -239,7 +249,7 @@ export class CryptidService {
   public async proposeAndExecuteTransaction(
     account: CryptidAccountDetails,
     transaction: Transaction
-  ): Promise<ProposeExecuteResult> {
+  ): Promise<ExecuteResult> {
     const transactionAccountKeypair = Keypair.generate();
     const cryptidTransaction = CryptidTransaction.fromSolanaInstructions(
       account,
@@ -255,33 +265,39 @@ export class CryptidService {
       )
       .instruction();
 
-    const middlewareProposeInstructions =
-      await this.executeMiddlewareInstructions(
-        account,
-        transactionAccountKeypair.publicKey,
-        "Propose"
-      );
-    const middlewareExecuteInstructions =
-      await this.executeMiddlewareInstructions(
-        account,
-        transactionAccountKeypair.publicKey,
-        "Execute"
-      );
+    const middlewareProposeResults = await this.executeMiddlewareInstructions(
+      account,
+      transactionAccountKeypair.publicKey,
+      "Propose"
+    );
+    const middlewareExecuteResults = await this.executeMiddlewareInstructions(
+      account,
+      transactionAccountKeypair.publicKey,
+      "Execute"
+    );
 
     const executeInstruction = await cryptidTransaction
       .execute(this.program, transactionAccountKeypair.publicKey)
+      .signers([
+        ...middlewareProposeResults.signers,
+        ...middlewareExecuteResults.signers,
+      ])
       .instruction();
 
-    const proposeExecuteTransaction = new Transaction().add(
+    const executeTransaction = new Transaction().add(
       proposeInstruction,
-      ...middlewareProposeInstructions,
-      ...middlewareExecuteInstructions,
+      ...middlewareProposeResults.instructions,
+      ...middlewareExecuteResults.instructions,
       executeInstruction
     );
 
     return {
-      proposeExecuteTransaction,
-      signers: [transactionAccountKeypair],
+      executeTransaction,
+      executeSigners: [
+        transactionAccountKeypair,
+        ...middlewareProposeResults.signers,
+        ...middlewareExecuteResults.signers,
+      ],
     };
   }
 
@@ -289,8 +305,8 @@ export class CryptidService {
     account: CryptidAccountDetails,
     transactionAccountAddress: PublicKey,
     cryptidTransaction?: CryptidTransaction
-  ): Promise<Transaction> {
-    const middlewareInstructions = await this.executeMiddlewareInstructions(
+  ): Promise<ExecuteResult> {
+    const middlewareResult = await this.executeMiddlewareInstructions(
       account,
       transactionAccountAddress,
       "Execute"
@@ -300,10 +316,16 @@ export class CryptidService {
       cryptidTransaction ||
       (await this.getCryptidTransaction(account, transactionAccountAddress));
 
-    return resolvedCryptidTransaction
+    const executeTransaction = await resolvedCryptidTransaction
       .execute(this.program, transactionAccountAddress)
-      .preInstructions(middlewareInstructions)
+      .preInstructions(middlewareResult.instructions)
+      .signers(middlewareResult.signers)
       .transaction();
+
+    return {
+      executeTransaction,
+      executeSigners: [...middlewareResult.signers],
+    };
   }
 
   public async directExecute(

--- a/packages/client/core/src/service/cryptid.ts
+++ b/packages/client/core/src/service/cryptid.ts
@@ -89,7 +89,7 @@ export class CryptidService {
     // do not do a lookup for index 0, as it is the default account
     const adaptedOffset = offset === 0 ? offset + 1 : offset;
 
-    const didAccount = didToPDA(did);
+    const didAccount = didToPDA(did)[0];
     const addresses = range(adaptedOffset, offset + page).map(
       (index) => getCryptidAccountAddress(didAccount, index)[0]
     );
@@ -137,7 +137,11 @@ export class CryptidService {
         ? details.middlewares[details.middlewares.length - 1]
         : undefined;
     return this.program.methods
-      .create(lastMiddleware?.address || null, details.index, details.bump)
+      .create(
+        lastMiddleware?.address || null,
+        details.index,
+        details.didAccountBump
+      )
       .accounts({
         cryptidAccount: details.address,
         didProgram: DID_SOL_PROGRAM,

--- a/packages/client/core/src/service/cryptid.ts
+++ b/packages/client/core/src/service/cryptid.ts
@@ -228,14 +228,10 @@ export class CryptidService {
       .postInstructions(middlewareInstructions)
       .transaction();
 
-    // don't sign
-    // const proposeTransaction = await this.sign(unsignedProposeTransaction, [
-    //   transactionAccountKeypair,
-    // ]);
-
     return {
       proposeTransaction: unsignedProposeTransaction,
-      transactionAccount: transactionAccountKeypair,
+      transactionAccount: transactionAccountKeypair.publicKey,
+      signers: [transactionAccountKeypair],
       cryptidTransactionRepresentation: cryptidTransaction,
     };
   }
@@ -285,14 +281,13 @@ export class CryptidService {
 
     return {
       proposeExecuteTransaction,
-      transactionAccount: transactionAccountKeypair,
+      signers: [transactionAccountKeypair],
     };
   }
 
   public async execute(
     account: CryptidAccountDetails,
     transactionAccountAddress: PublicKey,
-    signers: Keypair[] = [],
     cryptidTransaction?: CryptidTransaction
   ): Promise<Transaction> {
     const middlewareInstructions = await this.executeMiddlewareInstructions(
@@ -308,7 +303,6 @@ export class CryptidService {
     return resolvedCryptidTransaction
       .execute(this.program, transactionAccountAddress)
       .preInstructions(middlewareInstructions)
-      .signers([...signers])
       .transaction();
   }
 

--- a/packages/client/core/src/types.ts
+++ b/packages/client/core/src/types.ts
@@ -3,11 +3,16 @@ import { Cryptid } from "@identity.com/cryptid-idl";
 
 export { ExtendedCluster } from "./types/solana";
 export { Wallet } from "./types/crypto";
-export { ProposalResult } from "./types/cryptid";
+export {
+  ProposalResult,
+  ExecuteResult,
+  ExecuteArrayResult,
+} from "./types/cryptid";
 export {
   MiddlewareClient,
   GenericMiddlewareParams,
   ExecuteMiddlewareParams,
+  MiddlewareResult,
 } from "./types/middleware";
 
 export type TransactionAccountMeta =

--- a/packages/client/core/src/types/cryptid.ts
+++ b/packages/client/core/src/types/cryptid.ts
@@ -1,8 +1,18 @@
-import { PublicKey, Transaction } from "@solana/web3.js";
+import { Signer, Transaction } from "@solana/web3.js";
 import { CryptidTransaction } from "../lib/CryptidTransaction";
 
 export type ProposalResult = {
   proposeTransaction: Transaction;
-  transactionAccountAddress: PublicKey;
+  transactionAccount: Signer;
   cryptidTransactionRepresentation: CryptidTransaction;
+};
+
+export type ProposeExecuteResult = {
+  proposeExecuteTransaction: Transaction;
+  transactionAccount: Signer;
+};
+
+export type ProposeExecuteArrayResult = {
+  proposeExecuteTransactions: Transaction[];
+  transactionAccount: Signer;
 };

--- a/packages/client/core/src/types/cryptid.ts
+++ b/packages/client/core/src/types/cryptid.ts
@@ -4,16 +4,16 @@ import { CryptidTransaction } from "../lib/CryptidTransaction";
 export type ProposalResult = {
   proposeTransaction: Transaction;
   transactionAccount: PublicKey;
-  signers: Signer[];
+  proposeSigners: Signer[];
   cryptidTransactionRepresentation: CryptidTransaction;
 };
 
-export type ProposeExecuteResult = {
-  proposeExecuteTransaction: Transaction;
-  signers: Signer[];
+export type ExecuteResult = {
+  executeTransaction: Transaction;
+  executeSigners: Signer[];
 };
 
-export type ProposeExecuteArrayResult = {
-  proposeExecuteTransactions: Transaction[];
-  signers: Signer[];
+export type ExecuteArrayResult = {
+  executeTransactions: Transaction[];
+  executeSigners: Signer[];
 };

--- a/packages/client/core/src/types/cryptid.ts
+++ b/packages/client/core/src/types/cryptid.ts
@@ -1,18 +1,19 @@
-import { Signer, Transaction } from "@solana/web3.js";
+import { PublicKey, Signer, Transaction } from "@solana/web3.js";
 import { CryptidTransaction } from "../lib/CryptidTransaction";
 
 export type ProposalResult = {
   proposeTransaction: Transaction;
-  transactionAccount: Signer;
+  transactionAccount: PublicKey;
+  signers: Signer[];
   cryptidTransactionRepresentation: CryptidTransaction;
 };
 
 export type ProposeExecuteResult = {
   proposeExecuteTransaction: Transaction;
-  transactionAccount: Signer;
+  signers: Signer[];
 };
 
 export type ProposeExecuteArrayResult = {
   proposeExecuteTransactions: Transaction[];
-  transactionAccount: Signer;
+  signers: Signer[];
 };

--- a/packages/client/core/src/types/middleware.ts
+++ b/packages/client/core/src/types/middleware.ts
@@ -2,6 +2,7 @@ import {
   ConfirmOptions,
   Connection,
   PublicKey,
+  Signer,
   Transaction,
   TransactionInstruction,
 } from "@solana/web3.js";
@@ -24,8 +25,13 @@ export type ExecuteMiddlewareParams = GenericMiddlewareParams & {
   cryptidAccountDetails: CryptidAccountDetails;
 };
 
+export type MiddlewareResult = {
+  instructions: TransactionInstruction[];
+  signers: Signer[];
+};
+
 export interface MiddlewareClient<C extends GenericMiddlewareParams> {
   createMiddleware(params: C): Promise<Transaction>;
-  onPropose(params: ExecuteMiddlewareParams): Promise<TransactionInstruction[]>;
-  onExecute(params: ExecuteMiddlewareParams): Promise<TransactionInstruction[]>;
+  onPropose(params: ExecuteMiddlewareParams): Promise<MiddlewareResult>;
+  onExecute(params: ExecuteMiddlewareParams): Promise<MiddlewareResult>;
 }

--- a/packages/client/idl/src/check_pass.ts
+++ b/packages/client/idl/src/check_pass.ts
@@ -27,10 +27,6 @@ export type CheckPass = {
           "type": "publicKey"
         },
         {
-          "name": "bump",
-          "type": "u8"
-        },
-        {
           "name": "expireOnUse",
           "type": "bool"
         },
@@ -216,10 +212,6 @@ export const IDL: CheckPass = {
         {
           "name": "gatekeeperNetwork",
           "type": "publicKey"
-        },
-        {
-          "name": "bump",
-          "type": "u8"
         },
         {
           "name": "expireOnUse",

--- a/packages/client/idl/src/check_pass.ts
+++ b/packages/client/idl/src/check_pass.ts
@@ -58,7 +58,7 @@ export type CheckPass = {
           "isSigner": false
         },
         {
-          "name": "owner",
+          "name": "did",
           "isMut": false,
           "isSigner": false,
           "docs": [
@@ -245,7 +245,7 @@ export const IDL: CheckPass = {
           "isSigner": false
         },
         {
-          "name": "owner",
+          "name": "did",
           "isMut": false,
           "isSigner": false,
           "docs": [

--- a/packages/client/idl/src/cryptid.ts
+++ b/packages/client/idl/src/cryptid.ts
@@ -111,6 +111,10 @@ export type Cryptid = {
           "type": "u8"
         },
         {
+          "name": "cryptidAccountIndex",
+          "type": "u32"
+        },
+        {
           "name": "didAccountBump",
           "type": "u8"
         },
@@ -485,7 +489,7 @@ export type Cryptid = {
     {
       "code": 6003,
       "name": "WrongCryptidAccount",
-      "msg": "Wrong Cryptid account program"
+      "msg": "A wrong Cryptid account was passed"
     },
     {
       "code": 6004,
@@ -504,36 +508,31 @@ export type Cryptid = {
     },
     {
       "code": 6007,
-      "name": "KeyCannotChangeTransaction",
-      "msg": "Key is not a proposer for the transaction"
-    },
-    {
-      "code": 6008,
       "name": "KeyMustBeSigner",
       "msg": "Signer is not authorised to sign for this Cryptid account"
     },
     {
-      "code": 6009,
+      "code": 6008,
       "name": "CreatingWithZeroIndex",
       "msg": "Attempt to create a Cryptid account with index zero, reserved for the default account."
     },
     {
-      "code": 6010,
+      "code": 6009,
       "name": "IndexOutOfRange",
       "msg": "Index out of range."
     },
     {
-      "code": 6011,
+      "code": 6010,
       "name": "NoAccountFromSeeds",
       "msg": "No account from seeds."
     },
     {
-      "code": 6012,
+      "code": 6011,
       "name": "AccountNotFromSeeds",
       "msg": "Account not from seeds."
     },
     {
-      "code": 6013,
+      "code": 6012,
       "name": "IncorrectMiddleware",
       "msg": "The expected middleware did not approve the transaction."
     }
@@ -653,6 +652,10 @@ export const IDL: Cryptid = {
           "type": "u8"
         },
         {
+          "name": "cryptidAccountIndex",
+          "type": "u32"
+        },
+        {
           "name": "didAccountBump",
           "type": "u8"
         },
@@ -1027,7 +1030,7 @@ export const IDL: Cryptid = {
     {
       "code": 6003,
       "name": "WrongCryptidAccount",
-      "msg": "Wrong Cryptid account program"
+      "msg": "A wrong Cryptid account was passed"
     },
     {
       "code": 6004,
@@ -1046,36 +1049,31 @@ export const IDL: Cryptid = {
     },
     {
       "code": 6007,
-      "name": "KeyCannotChangeTransaction",
-      "msg": "Key is not a proposer for the transaction"
-    },
-    {
-      "code": 6008,
       "name": "KeyMustBeSigner",
       "msg": "Signer is not authorised to sign for this Cryptid account"
     },
     {
-      "code": 6009,
+      "code": 6008,
       "name": "CreatingWithZeroIndex",
       "msg": "Attempt to create a Cryptid account with index zero, reserved for the default account."
     },
     {
-      "code": 6010,
+      "code": 6009,
       "name": "IndexOutOfRange",
       "msg": "Index out of range."
     },
     {
-      "code": 6011,
+      "code": 6010,
       "name": "NoAccountFromSeeds",
       "msg": "No account from seeds."
     },
     {
-      "code": 6012,
+      "code": 6011,
       "name": "AccountNotFromSeeds",
       "msg": "Account not from seeds."
     },
     {
-      "code": 6013,
+      "code": 6012,
       "name": "IncorrectMiddleware",
       "msg": "The expected middleware did not approve the transaction."
     }

--- a/packages/client/idl/src/cryptid.ts
+++ b/packages/client/idl/src/cryptid.ts
@@ -173,6 +173,14 @@ export type Cryptid = {
           "type": "bytes"
         },
         {
+          "name": "cryptidAccountBump",
+          "type": "u8"
+        },
+        {
+          "name": "cryptidAccountIndex",
+          "type": "u32"
+        },
+        {
           "name": "didAccountBump",
           "type": "u8"
         },
@@ -732,6 +740,14 @@ export const IDL: Cryptid = {
         {
           "name": "controllerChain",
           "type": "bytes"
+        },
+        {
+          "name": "cryptidAccountBump",
+          "type": "u8"
+        },
+        {
+          "name": "cryptidAccountIndex",
+          "type": "u32"
         },
         {
           "name": "didAccountBump",

--- a/packages/client/idl/src/cryptid.ts
+++ b/packages/client/idl/src/cryptid.ts
@@ -233,6 +233,10 @@ export type Cryptid = {
           "type": "u8"
         },
         {
+          "name": "cryptidAccountIndex",
+          "type": "u32"
+        },
+        {
           "name": "didAccountBump",
           "type": "u8"
         },
@@ -772,6 +776,10 @@ export const IDL: Cryptid = {
         {
           "name": "cryptidAccountBump",
           "type": "u8"
+        },
+        {
+          "name": "cryptidAccountIndex",
+          "type": "u32"
         },
         {
           "name": "didAccountBump",

--- a/packages/client/idl/src/cryptid.ts
+++ b/packages/client/idl/src/cryptid.ts
@@ -52,7 +52,7 @@ export type Cryptid = {
           "type": "u32"
         },
         {
-          "name": "bump",
+          "name": "didAccountBump",
           "type": "u8"
         }
       ]
@@ -108,6 +108,10 @@ export type Cryptid = {
         },
         {
           "name": "cryptidAccountBump",
+          "type": "u8"
+        },
+        {
+          "name": "didAccountBump",
           "type": "u8"
         },
         {
@@ -222,6 +226,10 @@ export type Cryptid = {
         },
         {
           "name": "cryptidAccountBump",
+          "type": "u8"
+        },
+        {
+          "name": "didAccountBump",
           "type": "u8"
         },
         {
@@ -586,7 +594,7 @@ export const IDL: Cryptid = {
           "type": "u32"
         },
         {
-          "name": "bump",
+          "name": "didAccountBump",
           "type": "u8"
         }
       ]
@@ -642,6 +650,10 @@ export const IDL: Cryptid = {
         },
         {
           "name": "cryptidAccountBump",
+          "type": "u8"
+        },
+        {
+          "name": "didAccountBump",
           "type": "u8"
         },
         {
@@ -756,6 +768,10 @@ export const IDL: Cryptid = {
         },
         {
           "name": "cryptidAccountBump",
+          "type": "u8"
+        },
+        {
+          "name": "didAccountBump",
           "type": "u8"
         },
         {

--- a/packages/client/idl/src/cryptid.ts
+++ b/packages/client/idl/src/cryptid.ts
@@ -136,11 +136,11 @@ export type Cryptid = {
           ]
         },
         {
-          "name": "owner",
+          "name": "did",
           "isMut": false,
           "isSigner": false,
           "docs": [
-            "The owner of the Cryptid instance, typically a DID account"
+            "The did account owner of the Cryptid instance"
           ]
         },
         {
@@ -303,7 +303,7 @@ export type Cryptid = {
             "type": "publicKey"
           },
           {
-            "name": "owner",
+            "name": "did",
             "docs": [
               "The owner of the cryptid account (Typically a DID account)"
             ],
@@ -677,11 +677,11 @@ export const IDL: Cryptid = {
           ]
         },
         {
-          "name": "owner",
+          "name": "did",
           "isMut": false,
           "isSigner": false,
           "docs": [
-            "The owner of the Cryptid instance, typically a DID account"
+            "The did account owner of the Cryptid instance"
           ]
         },
         {
@@ -844,7 +844,7 @@ export const IDL: Cryptid = {
             "type": "publicKey"
           },
           {
-            "name": "owner",
+            "name": "did",
             "docs": [
               "The owner of the cryptid account (Typically a DID account)"
             ],

--- a/packages/client/idl/src/cryptid.ts
+++ b/packages/client/idl/src/cryptid.ts
@@ -144,6 +144,14 @@ export type Cryptid = {
           ]
         },
         {
+          "name": "didProgram",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "The program for the DID"
+          ]
+        },
+        {
           "name": "authority",
           "isMut": true,
           "isSigner": true
@@ -160,6 +168,14 @@ export type Cryptid = {
         }
       ],
       "args": [
+        {
+          "name": "controllerChain",
+          "type": "bytes"
+        },
+        {
+          "name": "didAccountBump",
+          "type": "u8"
+        },
         {
           "name": "instructions",
           "type": {
@@ -689,6 +705,14 @@ export const IDL: Cryptid = {
           ]
         },
         {
+          "name": "didProgram",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "The program for the DID"
+          ]
+        },
+        {
           "name": "authority",
           "isMut": true,
           "isSigner": true
@@ -705,6 +729,14 @@ export const IDL: Cryptid = {
         }
       ],
       "args": [
+        {
+          "name": "controllerChain",
+          "type": "bytes"
+        },
+        {
+          "name": "didAccountBump",
+          "type": "u8"
+        },
         {
           "name": "instructions",
           "type": {

--- a/packages/client/middleware/checkPass/src/index.ts
+++ b/packages/client/middleware/checkPass/src/index.ts
@@ -137,7 +137,7 @@ export class CheckPassMiddleware
       .accounts({
         middlewareAccount: params.middlewareAccount,
         transactionAccount: params.transactionAccount,
-        owner: params.cryptidAccountDetails.didAccount,
+        did: params.cryptidAccountDetails.didAccount,
         authority: params.authority.publicKey,
         expireFeatureAccount,
         gatewayToken,

--- a/packages/client/middleware/checkPass/src/index.ts
+++ b/packages/client/middleware/checkPass/src/index.ts
@@ -3,12 +3,9 @@ import {
   ExecuteMiddlewareParams,
   GenericMiddlewareParams,
   MiddlewareClient,
+  MiddlewareResult,
 } from "@identity.com/cryptid-core";
-import {
-  PublicKey,
-  Transaction,
-  TransactionInstruction,
-} from "@solana/web3.js";
+import { PublicKey, Transaction } from "@solana/web3.js";
 import { AnchorProvider, Program } from "@project-serum/anchor";
 import { CheckPass, CheckPassIDL } from "@identity.com/cryptid-idl";
 import * as anchor from "@project-serum/anchor";
@@ -111,13 +108,13 @@ export class CheckPassMiddleware
       .transaction();
   }
 
-  public async onPropose(): Promise<TransactionInstruction[]> {
-    return [];
+  public async onPropose(): Promise<MiddlewareResult> {
+    return { instructions: [], signers: [] };
   }
 
   public async onExecute(
     params: ExecuteMiddlewareParams
-  ): Promise<TransactionInstruction[]> {
+  ): Promise<MiddlewareResult> {
     const program = CheckPassMiddleware.getProgram(params);
 
     const middlewareAccount = await program.account.checkPass.fetch(
@@ -132,7 +129,7 @@ export class CheckPassMiddleware
         middlewareAccount.gatekeeperNetwork
       );
 
-    return program.methods
+    const instructions = await program.methods
       .executeMiddleware()
       .accounts({
         middlewareAccount: params.middlewareAccount,
@@ -146,5 +143,7 @@ export class CheckPassMiddleware
       })
       .instruction()
       .then(Array.of);
+
+    return { instructions, signers: [] };
   }
 }

--- a/packages/client/middleware/checkPass/src/index.ts
+++ b/packages/client/middleware/checkPass/src/index.ts
@@ -90,7 +90,7 @@ export class CheckPassMiddleware
   ): Promise<Transaction> {
     const program = CheckPassMiddleware.getProgram(params);
 
-    const [middlewareAccount, middlewareBump] = deriveMiddlewareAccountAddress(
+    const [middlewareAccount] = deriveMiddlewareAccountAddress(
       params.authority.publicKey,
       params.gatekeeperNetwork,
       params.failsafe,
@@ -100,7 +100,6 @@ export class CheckPassMiddleware
     return program.methods
       .create(
         params.gatekeeperNetwork,
-        middlewareBump,
         params.expirePassOnUse,
         params.failsafe || null,
         params.previousMiddleware || null

--- a/packages/client/middleware/checkRecipient/src/index.ts
+++ b/packages/client/middleware/checkRecipient/src/index.ts
@@ -2,6 +2,7 @@ import {
   CRYPTID_PROGRAM,
   ExecuteMiddlewareParams,
   GenericMiddlewareParams,
+  MiddlewareResult,
   MiddlewareClient,
 } from "@identity.com/cryptid-core";
 import {
@@ -105,7 +106,7 @@ export class CheckRecipientMiddleware
 
   public async onPropose(
     params: ExecuteMiddlewareParams
-  ): Promise<TransactionInstruction[]> {
+  ): Promise<MiddlewareResult> {
     const program = CheckRecipientMiddleware.getProgram(params);
 
     if (
@@ -114,7 +115,7 @@ export class CheckRecipientMiddleware
         params.middlewareAccount
       )
     ) {
-      return [];
+      return { instructions: [], signers: [] };
     }
 
     // If there is no previous middleware
@@ -126,12 +127,12 @@ export class CheckRecipientMiddleware
       params
     );
 
-    return [executeInstruction];
+    return { instructions: [executeInstruction], signers: [] };
   }
 
   public async onExecute(
     params: ExecuteMiddlewareParams
-  ): Promise<TransactionInstruction[]> {
+  ): Promise<MiddlewareResult> {
     const program = CheckRecipientMiddleware.getProgram(params);
 
     if (
@@ -149,9 +150,9 @@ export class CheckRecipientMiddleware
         params
       );
 
-      return [executeInstruction];
+      return { instructions: [executeInstruction], signers: [] };
     }
 
-    return [];
+    return { instructions: [], signers: [] };
   }
 }

--- a/packages/tests/src/create.ts
+++ b/packages/tests/src/create.ts
@@ -8,13 +8,13 @@ import { fund, createTestContext } from "./util/anchorUtils";
 chai.use(chaiAsPromised);
 const { expect } = chai;
 
-didTestCases.forEach(({ type, beforeFn }) => {
-  describe(`create (${type})`, () => {
+didTestCases.forEach(({ didType, getDidAccount }) => {
+  describe(`create (${didType})`, () => {
     const { authority, provider } = createTestContext();
 
-    before(`Set up ${type} account`, async () => {
+    before(`Set up ${didType} account`, async () => {
       await fund(authority.publicKey, 10 * LAMPORTS_PER_SOL);
-      await beforeFn(authority);
+      await getDidAccount(authority);
     });
 
     it("cannot create a zero index cryptid account", async () => {

--- a/packages/tests/src/directExecute.ts
+++ b/packages/tests/src/directExecute.ts
@@ -205,9 +205,7 @@ didTestCases.forEach(({ didType, getDidAccount }) => {
           const signedTransaction = await secondKeyCryptid.directExecute(
             makeTransaction(recipient.publicKey)
           );
-          await secondKeyCryptid.send(signedTransaction, [], {
-            skipPreflight: true,
-          });
+          await secondKeyCryptid.send(signedTransaction);
         };
 
         const previousBalance = await balanceOf(cryptid.address());

--- a/packages/tests/src/directExecute.ts
+++ b/packages/tests/src/directExecute.ts
@@ -30,6 +30,8 @@ didTestCases.forEach(({ type, beforeFn }) => {
     const { program, authority, provider } = createTestContext();
 
     let didAccount: PublicKey;
+    let didAccountBump: number;
+
     let cryptidAccount: PublicKey;
     let cryptidBump: number;
 
@@ -53,6 +55,7 @@ didTestCases.forEach(({ type, beforeFn }) => {
           Buffer.from([]), // no controller chain
           [instructionData],
           cryptidBump,
+          didAccountBump,
           0
         )
         .accounts({
@@ -69,7 +72,7 @@ didTestCases.forEach(({ type, beforeFn }) => {
 
     before("Set up DID account", async () => {
       await fund(authority.publicKey, 10 * LAMPORTS_PER_SOL);
-      didAccount = await beforeFn(authority);
+      [didAccount, didAccountBump] = await beforeFn(authority);
     });
 
     before("Set up generative Cryptid Account", async () => {

--- a/packages/tests/src/middleware/chaining.ts
+++ b/packages/tests/src/middleware/chaining.ts
@@ -148,13 +148,15 @@ describe("Middleware chaining", () => {
     // no gateway token exists for the authority
 
     // send the propose tx
-    const { proposeTransaction, transactionAccount, signers } =
+    const { proposeTransaction, transactionAccount, proposeSigners } =
       await cryptid.propose(makeTransaction());
-    await cryptid.send(proposeTransaction, signers);
+    await cryptid.send(proposeTransaction, proposeSigners);
 
     // send the execute tx, which fails to pass through the middleware
-    const [executeTransaction] = await cryptid.execute(transactionAccount);
-    const shouldFail = cryptid.send(executeTransaction);
+    const { executeTransactions, executeSigners } = await cryptid.execute(
+      transactionAccount
+    );
+    const shouldFail = cryptid.send(executeTransactions[0], executeSigners);
 
     // TODO expose the error message
     return expect(shouldFail).to.be.rejected;
@@ -165,13 +167,15 @@ describe("Middleware chaining", () => {
     await createGatewayToken(authority.publicKey);
 
     // send the propose tx
-    const { proposeTransaction, transactionAccount, signers } =
+    const { proposeTransaction, transactionAccount, proposeSigners } =
       await cryptid.propose(makeTransaction());
-    await cryptid.send(proposeTransaction, signers);
+    await cryptid.send(proposeTransaction, proposeSigners);
 
     // send the execute tx, which fails to pass through the middleware
-    const [executeTransaction] = await cryptid.execute(transactionAccount);
-    const shouldFail = cryptid.send(executeTransaction);
+    const { executeTransactions, executeSigners } = await cryptid.execute(
+      transactionAccount
+    );
+    const shouldFail = cryptid.send(executeTransactions[0], executeSigners);
 
     // TODO expose the error message
     return expect(shouldFail).to.be.rejected;
@@ -184,16 +188,18 @@ describe("Middleware chaining", () => {
     await createGatewayToken(authority.publicKey);
 
     // send the propose tx
-    const { proposeTransaction, transactionAccount, signers } =
+    const { proposeTransaction, transactionAccount, proposeSigners } =
       await cryptid.propose(makeTransaction());
-    await cryptid.send(proposeTransaction, signers);
+    await cryptid.send(proposeTransaction, proposeSigners);
 
     // wait for the period required by the time-delay middleware
     await sleep((TIME_DELAY_SECONDS + 2) * 1000);
 
     // send the execute tx (executing the middleware)
-    const [executeTransaction] = await cryptid.execute(transactionAccount);
-    await cryptid.send(executeTransaction);
+    const { executeTransactions, executeSigners } = await cryptid.execute(
+      transactionAccount
+    );
+    await cryptid.send(executeTransactions[0], executeSigners);
 
     const currentBalance = await balanceOf(cryptid.address());
     expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed
@@ -204,9 +210,9 @@ describe("Middleware chaining", () => {
     await createGatewayToken(authority.publicKey);
 
     // send the propose tx
-    const { proposeTransaction, transactionAccount, signers } =
+    const { proposeTransaction, transactionAccount, proposeSigners } =
       await cryptid.propose(makeTransaction());
-    await cryptid.send(proposeTransaction, signers);
+    await cryptid.send(proposeTransaction, proposeSigners);
 
     // wait for the period required by the time-delay middleware
     await sleep((TIME_DELAY_SECONDS + 2) * 1000);
@@ -222,10 +228,12 @@ describe("Middleware chaining", () => {
 
     // send the execute tx, which fails to pass through the middleware because
     // the time-delay middleware expects the check-pass middleware to have been executed first
-    const [executeTransaction] = await backwardsCryptid.execute(
-      transactionAccount
+    const { executeTransactions, executeSigners } =
+      await backwardsCryptid.execute(transactionAccount);
+    const shouldFail = backwardsCryptid.send(
+      executeTransactions[0],
+      executeSigners
     );
-    const shouldFail = backwardsCryptid.send(executeTransaction);
 
     // TODO expose the error message
     return expect(shouldFail).to.be.rejected;
@@ -236,9 +244,9 @@ describe("Middleware chaining", () => {
     await createGatewayToken(authority.publicKey);
 
     // send the propose tx
-    const { proposeTransaction, transactionAccount, signers } =
+    const { proposeTransaction, transactionAccount, proposeSigners } =
       await cryptid.propose(makeTransaction());
-    await cryptid.send(proposeTransaction, signers);
+    await cryptid.send(proposeTransaction, proposeSigners);
 
     // leave out the timedelay middleware and try to pass a tx with just the check-pass one
     const cryptidWithoutTimeDelay = await Cryptid.build(
@@ -252,10 +260,12 @@ describe("Middleware chaining", () => {
 
     // send the execute tx, which fails to pass through the middleware because
     // the time-delay middleware expects the check-pass middleware to have been executed first
-    const [executeTransaction] = await cryptidWithoutTimeDelay.execute(
-      transactionAccount
+    const { executeTransactions, executeSigners } =
+      await cryptidWithoutTimeDelay.execute(transactionAccount);
+    const shouldFail = cryptidWithoutTimeDelay.send(
+      executeTransactions[0],
+      executeSigners
     );
-    const shouldFail = cryptidWithoutTimeDelay.send(executeTransaction);
 
     return expect(shouldFail).to.be.rejectedWith(
       "Error Code: IncorrectMiddleware"

--- a/packages/tests/src/middleware/chaining.ts
+++ b/packages/tests/src/middleware/chaining.ts
@@ -263,9 +263,7 @@ describe("Middleware chaining", () => {
     const { proposeTransaction, transactionAccount } = await cryptid.propose(
       makeTransaction()
     );
-    await cryptid.send(proposeTransaction, [transactionAccount], {
-      skipPreflight: true,
-    });
+    await cryptid.send(proposeTransaction, [transactionAccount]);
 
     // leave out the timedelay middleware and try to pass a tx with just the check-pass one
     const cryptidWithoutTimeDelay = await Cryptid.build(
@@ -282,11 +280,10 @@ describe("Middleware chaining", () => {
     const [executeTransaction] = await cryptidWithoutTimeDelay.execute(
       transactionAccount.publicKey
     );
-    const shouldFail = cryptidWithoutTimeDelay.send(executeTransaction, [], {
-      skipPreflight: true,
-    });
+    const shouldFail = cryptidWithoutTimeDelay.send(executeTransaction);
 
-    // TODO expose the error message
-    return expect(shouldFail).to.be.rejected;
+    return expect(shouldFail).to.be.rejectedWith(
+      "Error Code: IncorrectMiddleware"
+    );
   });
 });

--- a/packages/tests/src/middleware/chaining.ts
+++ b/packages/tests/src/middleware/chaining.ts
@@ -148,15 +148,18 @@ describe("Middleware chaining", () => {
     // no gateway token exists for the authority
 
     // send the propose tx
-    const { proposeTransaction, transactionAccountAddress } =
-      await cryptid.propose(makeTransaction());
-    await cryptid.send(proposeTransaction, { skipPreflight: true });
+    const { proposeTransaction, transactionAccount } = await cryptid.propose(
+      makeTransaction()
+    );
+    await cryptid.send(proposeTransaction, [transactionAccount], {
+      skipPreflight: true,
+    });
 
     // send the execute tx, which fails to pass through the middleware
     const [executeTransaction] = await cryptid.execute(
-      transactionAccountAddress
+      transactionAccount.publicKey
     );
-    const shouldFail = cryptid.send(executeTransaction, {
+    const shouldFail = cryptid.send(executeTransaction, [], {
       skipPreflight: true,
     });
 
@@ -169,15 +172,18 @@ describe("Middleware chaining", () => {
     await createGatewayToken(authority.publicKey);
 
     // send the propose tx
-    const { proposeTransaction, transactionAccountAddress } =
-      await cryptid.propose(makeTransaction());
-    await cryptid.send(proposeTransaction, { skipPreflight: true });
+    const { proposeTransaction, transactionAccount } = await cryptid.propose(
+      makeTransaction()
+    );
+    await cryptid.send(proposeTransaction, [transactionAccount], {
+      skipPreflight: true,
+    });
 
     // send the execute tx, which fails to pass through the middleware
     const [executeTransaction] = await cryptid.execute(
-      transactionAccountAddress
+      transactionAccount.publicKey
     );
-    const shouldFail = cryptid.send(executeTransaction, {
+    const shouldFail = cryptid.send(executeTransaction, [], {
       skipPreflight: true,
     });
 
@@ -192,18 +198,21 @@ describe("Middleware chaining", () => {
     await createGatewayToken(authority.publicKey);
 
     // send the propose tx
-    const { proposeTransaction, transactionAccountAddress } =
-      await cryptid.propose(makeTransaction());
-    await cryptid.send(proposeTransaction, { skipPreflight: true });
+    const { proposeTransaction, transactionAccount } = await cryptid.propose(
+      makeTransaction()
+    );
+    await cryptid.send(proposeTransaction, [transactionAccount], {
+      skipPreflight: true,
+    });
 
     // wait for the period required by the time-delay middleware
     await sleep((TIME_DELAY_SECONDS + 2) * 1000);
 
     // send the execute tx (executing the middleware)
     const [executeTransaction] = await cryptid.execute(
-      transactionAccountAddress
+      transactionAccount.publicKey
     );
-    await cryptid.send(executeTransaction, { skipPreflight: true });
+    await cryptid.send(executeTransaction, [], { skipPreflight: true });
 
     const currentBalance = await balanceOf(cryptid.address());
     expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed
@@ -214,9 +223,12 @@ describe("Middleware chaining", () => {
     await createGatewayToken(authority.publicKey);
 
     // send the propose tx
-    const { proposeTransaction, transactionAccountAddress } =
-      await cryptid.propose(makeTransaction());
-    await cryptid.send(proposeTransaction, { skipPreflight: true });
+    const { proposeTransaction, transactionAccount } = await cryptid.propose(
+      makeTransaction()
+    );
+    await cryptid.send(proposeTransaction, [transactionAccount], {
+      skipPreflight: true,
+    });
 
     // wait for the period required by the time-delay middleware
     await sleep((TIME_DELAY_SECONDS + 2) * 1000);
@@ -233,9 +245,9 @@ describe("Middleware chaining", () => {
     // send the execute tx, which fails to pass through the middleware because
     // the time-delay middleware expects the check-pass middleware to have been executed first
     const [executeTransaction] = await backwardsCryptid.execute(
-      transactionAccountAddress
+      transactionAccount.publicKey
     );
-    const shouldFail = backwardsCryptid.send(executeTransaction, {
+    const shouldFail = backwardsCryptid.send(executeTransaction, [], {
       skipPreflight: true,
     });
 
@@ -248,9 +260,12 @@ describe("Middleware chaining", () => {
     await createGatewayToken(authority.publicKey);
 
     // send the propose tx
-    const { proposeTransaction, transactionAccountAddress } =
-      await cryptid.propose(makeTransaction());
-    await cryptid.send(proposeTransaction, { skipPreflight: true });
+    const { proposeTransaction, transactionAccount } = await cryptid.propose(
+      makeTransaction()
+    );
+    await cryptid.send(proposeTransaction, [transactionAccount], {
+      skipPreflight: true,
+    });
 
     // leave out the timedelay middleware and try to pass a tx with just the check-pass one
     const cryptidWithoutTimeDelay = await Cryptid.build(
@@ -265,9 +280,9 @@ describe("Middleware chaining", () => {
     // send the execute tx, which fails to pass through the middleware because
     // the time-delay middleware expects the check-pass middleware to have been executed first
     const [executeTransaction] = await cryptidWithoutTimeDelay.execute(
-      transactionAccountAddress
+      transactionAccount.publicKey
     );
-    const shouldFail = cryptidWithoutTimeDelay.send(executeTransaction, {
+    const shouldFail = cryptidWithoutTimeDelay.send(executeTransaction, [], {
       skipPreflight: true,
     });
 

--- a/packages/tests/src/middleware/chaining.ts
+++ b/packages/tests/src/middleware/chaining.ts
@@ -148,20 +148,13 @@ describe("Middleware chaining", () => {
     // no gateway token exists for the authority
 
     // send the propose tx
-    const { proposeTransaction, transactionAccount } = await cryptid.propose(
-      makeTransaction()
-    );
-    await cryptid.send(proposeTransaction, [transactionAccount], {
-      skipPreflight: true,
-    });
+    const { proposeTransaction, transactionAccount, signers } =
+      await cryptid.propose(makeTransaction());
+    await cryptid.send(proposeTransaction, signers);
 
     // send the execute tx, which fails to pass through the middleware
-    const [executeTransaction] = await cryptid.execute(
-      transactionAccount.publicKey
-    );
-    const shouldFail = cryptid.send(executeTransaction, [], {
-      skipPreflight: true,
-    });
+    const [executeTransaction] = await cryptid.execute(transactionAccount);
+    const shouldFail = cryptid.send(executeTransaction);
 
     // TODO expose the error message
     return expect(shouldFail).to.be.rejected;
@@ -172,20 +165,13 @@ describe("Middleware chaining", () => {
     await createGatewayToken(authority.publicKey);
 
     // send the propose tx
-    const { proposeTransaction, transactionAccount } = await cryptid.propose(
-      makeTransaction()
-    );
-    await cryptid.send(proposeTransaction, [transactionAccount], {
-      skipPreflight: true,
-    });
+    const { proposeTransaction, transactionAccount, signers } =
+      await cryptid.propose(makeTransaction());
+    await cryptid.send(proposeTransaction, signers);
 
     // send the execute tx, which fails to pass through the middleware
-    const [executeTransaction] = await cryptid.execute(
-      transactionAccount.publicKey
-    );
-    const shouldFail = cryptid.send(executeTransaction, [], {
-      skipPreflight: true,
-    });
+    const [executeTransaction] = await cryptid.execute(transactionAccount);
+    const shouldFail = cryptid.send(executeTransaction);
 
     // TODO expose the error message
     return expect(shouldFail).to.be.rejected;
@@ -198,21 +184,16 @@ describe("Middleware chaining", () => {
     await createGatewayToken(authority.publicKey);
 
     // send the propose tx
-    const { proposeTransaction, transactionAccount } = await cryptid.propose(
-      makeTransaction()
-    );
-    await cryptid.send(proposeTransaction, [transactionAccount], {
-      skipPreflight: true,
-    });
+    const { proposeTransaction, transactionAccount, signers } =
+      await cryptid.propose(makeTransaction());
+    await cryptid.send(proposeTransaction, signers);
 
     // wait for the period required by the time-delay middleware
     await sleep((TIME_DELAY_SECONDS + 2) * 1000);
 
     // send the execute tx (executing the middleware)
-    const [executeTransaction] = await cryptid.execute(
-      transactionAccount.publicKey
-    );
-    await cryptid.send(executeTransaction, [], { skipPreflight: true });
+    const [executeTransaction] = await cryptid.execute(transactionAccount);
+    await cryptid.send(executeTransaction);
 
     const currentBalance = await balanceOf(cryptid.address());
     expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed
@@ -223,12 +204,9 @@ describe("Middleware chaining", () => {
     await createGatewayToken(authority.publicKey);
 
     // send the propose tx
-    const { proposeTransaction, transactionAccount } = await cryptid.propose(
-      makeTransaction()
-    );
-    await cryptid.send(proposeTransaction, [transactionAccount], {
-      skipPreflight: true,
-    });
+    const { proposeTransaction, transactionAccount, signers } =
+      await cryptid.propose(makeTransaction());
+    await cryptid.send(proposeTransaction, signers);
 
     // wait for the period required by the time-delay middleware
     await sleep((TIME_DELAY_SECONDS + 2) * 1000);
@@ -245,11 +223,9 @@ describe("Middleware chaining", () => {
     // send the execute tx, which fails to pass through the middleware because
     // the time-delay middleware expects the check-pass middleware to have been executed first
     const [executeTransaction] = await backwardsCryptid.execute(
-      transactionAccount.publicKey
+      transactionAccount
     );
-    const shouldFail = backwardsCryptid.send(executeTransaction, [], {
-      skipPreflight: true,
-    });
+    const shouldFail = backwardsCryptid.send(executeTransaction);
 
     // TODO expose the error message
     return expect(shouldFail).to.be.rejected;
@@ -260,10 +236,9 @@ describe("Middleware chaining", () => {
     await createGatewayToken(authority.publicKey);
 
     // send the propose tx
-    const { proposeTransaction, transactionAccount } = await cryptid.propose(
-      makeTransaction()
-    );
-    await cryptid.send(proposeTransaction, [transactionAccount]);
+    const { proposeTransaction, transactionAccount, signers } =
+      await cryptid.propose(makeTransaction());
+    await cryptid.send(proposeTransaction, signers);
 
     // leave out the timedelay middleware and try to pass a tx with just the check-pass one
     const cryptidWithoutTimeDelay = await Cryptid.build(
@@ -278,7 +253,7 @@ describe("Middleware chaining", () => {
     // send the execute tx, which fails to pass through the middleware because
     // the time-delay middleware expects the check-pass middleware to have been executed first
     const [executeTransaction] = await cryptidWithoutTimeDelay.execute(
-      transactionAccount.publicKey
+      transactionAccount
     );
     const shouldFail = cryptidWithoutTimeDelay.send(executeTransaction);
 

--- a/packages/tests/src/middleware/checkPass.ts
+++ b/packages/tests/src/middleware/checkPass.ts
@@ -147,9 +147,15 @@ describe("Middleware: checkPass", () => {
     instruction: InstructionData = transferInstructionData
   ) =>
     program.methods
-      .proposeTransaction([instruction], 2)
+      .proposeTransaction(
+        Buffer.from([]), // no controller chain,
+        cryptid.details.didAccountBump,
+        [instruction],
+        2
+      )
       .accounts({
         cryptidAccount: cryptid.address(),
+        didProgram: DID_SOL_PROGRAM,
         did: didAccount,
         authority: authority.publicKey,
         transactionAccount: transactionAccount.publicKey,

--- a/packages/tests/src/middleware/checkPass.ts
+++ b/packages/tests/src/middleware/checkPass.ts
@@ -59,13 +59,14 @@ describe("Middleware: checkPass", () => {
   let expireFeatureAccount: PublicKey;
 
   let didAccount: PublicKey;
+  let didAccountBump: number;
   let cryptidAccount: PublicKey;
   let cryptidBump: number;
   let cryptidIndex = 0; // The index of the cryptid account owned by that DID - increment when creating a new account
   let cryptid: CryptidClient;
 
   let middlewareAccount: PublicKey;
-  let middlewareBump: number;
+  // let middlewareBump: number;
 
   const recipient = Keypair.generate();
   const transferInstructionData = cryptidTransferInstruction(LAMPORTS_PER_SOL); // 1 SOL
@@ -83,7 +84,7 @@ describe("Middleware: checkPass", () => {
     expireGatewayTokenOnUse: boolean,
     failsafe?: PublicKey
   ) => {
-    [middlewareAccount, middlewareBump] = deriveMiddlewareAccountAddress(
+    [middlewareAccount] = deriveMiddlewareAccountAddress(
       authority.publicKey,
       gatekeeperNetwork.publicKey,
       failsafe
@@ -92,7 +93,6 @@ describe("Middleware: checkPass", () => {
     await checkPassMiddlewareProgram.methods
       .create(
         gatekeeperNetwork.publicKey,
-        middlewareBump,
         expireGatewayTokenOnUse,
         failsafe || null,
         null
@@ -105,7 +105,7 @@ describe("Middleware: checkPass", () => {
   };
 
   const setUpMiddlewareWithClient = async (failsafe?: PublicKey) => {
-    [middlewareAccount, middlewareBump] = deriveMiddlewareAccountAddress(
+    [middlewareAccount] = deriveMiddlewareAccountAddress(
       authority.publicKey,
       gatekeeperNetwork.publicKey,
       failsafe
@@ -129,6 +129,7 @@ describe("Middleware: checkPass", () => {
     [cryptidAccount, cryptidBump] = await createCryptidAccount(
       program,
       didAccount,
+      didAccountBump,
       middlewareAccount,
       ++cryptidIndex
     );
@@ -181,6 +182,7 @@ describe("Middleware: checkPass", () => {
       .executeTransaction(
         Buffer.from([]), // no controller chain
         cryptidBump,
+        didAccountBump,
         0
       )
       .accounts({
@@ -215,7 +217,7 @@ describe("Middleware: checkPass", () => {
 
   before("Set up DID account", async () => {
     await fund(authority.publicKey, 10 * LAMPORTS_PER_SOL);
-    didAccount = await initializeDIDAccount(authority);
+    [didAccount, didAccountBump] = await initializeDIDAccount(authority);
   });
 
   before("Fund the gatekeeper", () => fund(gatekeeper.publicKey));
@@ -240,7 +242,7 @@ describe("Middleware: checkPass", () => {
 
   context("with the cryptid client", () => {
     beforeEach("Set up middleware PDA", async () => {
-      [middlewareAccount, middlewareBump] = deriveMiddlewareAccountAddress(
+      [middlewareAccount] = deriveMiddlewareAccountAddress(
         authority.publicKey,
         gatekeeperNetwork.publicKey
       );

--- a/packages/tests/src/middleware/checkPass.ts
+++ b/packages/tests/src/middleware/checkPass.ts
@@ -258,13 +258,15 @@ describe("Middleware: checkPass", () => {
       // no gateway token exists for the authority
 
       // send the propose tx
-      const { proposeTransaction, transactionAccount, signers } =
+      const { proposeTransaction, transactionAccount, proposeSigners } =
         await cryptid.propose(makeTransaction());
-      await cryptid.send(proposeTransaction, signers);
+      await cryptid.send(proposeTransaction, proposeSigners);
 
       // send the execute tx, which fails to pass through the middleware
-      const [executeTransaction] = await cryptid.execute(transactionAccount);
-      const shouldFail = cryptid.send(executeTransaction);
+      const { executeTransactions, executeSigners } = await cryptid.execute(
+        transactionAccount
+      );
+      const shouldFail = cryptid.send(executeTransactions[0], executeSigners);
 
       // TODO expose the error message
       return expect(shouldFail).to.be.rejected;
@@ -277,13 +279,15 @@ describe("Middleware: checkPass", () => {
       await createGatewayToken(authority.publicKey);
 
       // send the propose tx
-      const { proposeTransaction, transactionAccount, signers } =
+      const { proposeTransaction, transactionAccount, proposeSigners } =
         await cryptid.propose(makeTransaction());
-      await cryptid.send(proposeTransaction, signers);
+      await cryptid.send(proposeTransaction, proposeSigners);
 
       // send the execute tx (executing the middleware)
-      const [executeTransaction] = await cryptid.execute(transactionAccount);
-      await cryptid.send(executeTransaction);
+      const { executeTransactions, executeSigners } = await cryptid.execute(
+        transactionAccount
+      );
+      await cryptid.send(executeTransactions[0], executeSigners);
 
       const currentBalance = await balanceOf(cryptid.address());
       expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed
@@ -295,10 +299,10 @@ describe("Middleware: checkPass", () => {
       // issue a gateway token to the authority
       await createGatewayToken(authority.publicKey);
 
-      const { proposeExecuteTransactions, signers } =
+      const { executeTransactions, executeSigners } =
         await cryptid.proposeAndExecute(makeTransaction(), true);
-      expect(proposeExecuteTransactions.length).to.equal(1);
-      await cryptid.send(proposeExecuteTransactions[0], signers);
+      expect(executeTransactions.length).to.equal(1);
+      await cryptid.send(executeTransactions[0], executeSigners);
 
       const currentBalance = await balanceOf(cryptid.address());
       expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed
@@ -322,11 +326,11 @@ describe("Middleware: checkPass", () => {
       const previousBalance = await balanceOf(cryptid.address());
 
       // no gateway token exists for the authority
-      const { proposeExecuteTransactions, signers } =
+      const { executeTransactions, executeSigners } =
         await cryptid.proposeAndExecute(makeTransaction(), true);
-      expect(proposeExecuteTransactions.length).to.equal(1);
+      expect(executeTransactions.length).to.equal(1);
 
-      await cryptid.send(proposeExecuteTransactions[0], signers);
+      await cryptid.send(executeTransactions[0], executeSigners);
 
       const currentBalance = await balanceOf(cryptid.address());
       expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed
@@ -341,11 +345,11 @@ describe("Middleware: checkPass", () => {
       });
 
       // no gateway token exists for the authority
-      const { proposeExecuteTransactions, signers } =
+      const { executeTransactions, executeSigners } =
         await cryptid.proposeAndExecute(makeTransaction(), true);
-      expect(proposeExecuteTransactions.length).to.equal(1);
+      expect(executeTransactions.length).to.equal(1);
 
-      const shouldFail = cryptid.send(proposeExecuteTransactions[0], signers);
+      const shouldFail = cryptid.send(executeTransactions[0], executeSigners);
 
       // TODO expose the error message
       return expect(shouldFail).to.be.rejected;

--- a/packages/tests/src/middleware/checkPass.ts
+++ b/packages/tests/src/middleware/checkPass.ts
@@ -165,7 +165,7 @@ describe("Middleware: checkPass", () => {
       .proposeTransaction([instruction], 2)
       .accounts({
         cryptidAccount,
-        owner: didAccount,
+        did: didAccount,
         authority: authority.publicKey,
         transactionAccount: transactionAccount.publicKey,
       })
@@ -206,7 +206,7 @@ describe("Middleware: checkPass", () => {
       .accounts({
         middlewareAccount,
         transactionAccount: transactionAccount.publicKey,
-        owner: didAccount,
+        did: didAccount,
         authority: authority.publicKey,
         expireFeatureAccount,
         gatewayToken,

--- a/packages/tests/src/middleware/checkRecipient.ts
+++ b/packages/tests/src/middleware/checkRecipient.ts
@@ -80,17 +80,13 @@ describe("Middleware: checkRecipient", () => {
     );
 
     console.log("sending");
-    await cryptid.send(proposeTransaction, [transactionAccount], {
-      skipPreflight: true,
-    });
+    await cryptid.send(proposeTransaction, [transactionAccount]);
 
     // send the execute tx
     const [executeTransaction] = await cryptid.execute(
       transactionAccount.publicKey
     );
-    await cryptid.send(executeTransaction, [], {
-      skipPreflight: true,
-    });
+    await cryptid.send(executeTransaction);
 
     const currentBalance = await balanceOf(cryptid.address());
     expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed
@@ -108,24 +104,19 @@ describe("Middleware: checkRecipient", () => {
     // propose the Cryptid transaction
     const { proposeTransaction, transactionAccount } =
       await cryptidWithoutMiddleware.propose(makeTransaction());
-    await cryptidWithoutMiddleware.send(
-      proposeTransaction,
-      [transactionAccount],
-      {
-        skipPreflight: true,
-      }
-    );
+    await cryptidWithoutMiddleware.send(proposeTransaction, [
+      transactionAccount,
+    ]);
 
     // send the execute tx - this will fail since the middeware was not used
     const [executeTransaction] = await cryptidWithoutMiddleware.execute(
       transactionAccount.publicKey
     );
-    const shouldFail = cryptidWithoutMiddleware.send(executeTransaction, [], {
-      skipPreflight: true,
-    });
+    const shouldFail = cryptidWithoutMiddleware.send(executeTransaction);
 
-    // TODO expose the error message
-    return expect(shouldFail).to.be.rejected;
+    return expect(shouldFail).to.be.rejectedWith(
+      "Error Code: IncorrectMiddleware"
+    );
   });
 
   it("blocks a transfer to a different recipient", async () => {
@@ -137,11 +128,10 @@ describe("Middleware: checkRecipient", () => {
     const { proposeTransaction, transactionAccount } = await cryptid.propose(
       makeTransaction()
     );
-    const shouldFail = cryptid.send(proposeTransaction, [transactionAccount], {
-      skipPreflight: true,
-    });
+    const shouldFail = cryptid.send(proposeTransaction, [transactionAccount]);
 
-    // TODO expose the error message
-    return expect(shouldFail).to.be.rejected;
+    return expect(shouldFail).to.be.rejectedWith(
+      "Error Code: InvalidRecipient."
+    );
   });
 });

--- a/packages/tests/src/middleware/checkRecipient.ts
+++ b/packages/tests/src/middleware/checkRecipient.ts
@@ -75,17 +75,14 @@ describe("Middleware: checkRecipient", () => {
     console.log("creating");
 
     // propose the Cryptid transaction
-    const { proposeTransaction, transactionAccount } = await cryptid.propose(
-      makeTransaction()
-    );
+    const { proposeTransaction, transactionAccount, signers } =
+      await cryptid.propose(makeTransaction());
 
     console.log("sending");
-    await cryptid.send(proposeTransaction, [transactionAccount]);
+    await cryptid.send(proposeTransaction, signers);
 
     // send the execute tx
-    const [executeTransaction] = await cryptid.execute(
-      transactionAccount.publicKey
-    );
+    const [executeTransaction] = await cryptid.execute(transactionAccount);
     await cryptid.send(executeTransaction);
 
     const currentBalance = await balanceOf(cryptid.address());
@@ -102,15 +99,13 @@ describe("Middleware: checkRecipient", () => {
       { connection: provider.connection }
     );
     // propose the Cryptid transaction
-    const { proposeTransaction, transactionAccount } =
+    const { proposeTransaction, transactionAccount, signers } =
       await cryptidWithoutMiddleware.propose(makeTransaction());
-    await cryptidWithoutMiddleware.send(proposeTransaction, [
-      transactionAccount,
-    ]);
+    await cryptidWithoutMiddleware.send(proposeTransaction, signers);
 
     // send the execute tx - this will fail since the middeware was not used
     const [executeTransaction] = await cryptidWithoutMiddleware.execute(
-      transactionAccount.publicKey
+      transactionAccount
     );
     const shouldFail = cryptidWithoutMiddleware.send(executeTransaction);
 
@@ -125,10 +120,10 @@ describe("Middleware: checkRecipient", () => {
 
     // propose the Cryptid transaction. Since the checkRecipient middleware
     // executes on propose, this tx will fail
-    const { proposeTransaction, transactionAccount } = await cryptid.propose(
+    const { proposeTransaction, signers } = await cryptid.propose(
       makeTransaction()
     );
-    const shouldFail = cryptid.send(proposeTransaction, [transactionAccount]);
+    const shouldFail = cryptid.send(proposeTransaction, signers);
 
     return expect(shouldFail).to.be.rejectedWith(
       "Error Code: InvalidRecipient."

--- a/packages/tests/src/middleware/checkRecipient.ts
+++ b/packages/tests/src/middleware/checkRecipient.ts
@@ -75,17 +75,20 @@ describe("Middleware: checkRecipient", () => {
     console.log("creating");
 
     // propose the Cryptid transaction
-    const { proposeTransaction, transactionAccountAddress } =
-      await cryptid.propose(makeTransaction());
+    const { proposeTransaction, transactionAccount } = await cryptid.propose(
+      makeTransaction()
+    );
 
     console.log("sending");
-    await cryptid.send(proposeTransaction, { skipPreflight: true });
+    await cryptid.send(proposeTransaction, [transactionAccount], {
+      skipPreflight: true,
+    });
 
     // send the execute tx
     const [executeTransaction] = await cryptid.execute(
-      transactionAccountAddress
+      transactionAccount.publicKey
     );
-    await cryptid.send(executeTransaction, {
+    await cryptid.send(executeTransaction, [], {
       skipPreflight: true,
     });
 
@@ -103,17 +106,21 @@ describe("Middleware: checkRecipient", () => {
       { connection: provider.connection }
     );
     // propose the Cryptid transaction
-    const { proposeTransaction, transactionAccountAddress } =
+    const { proposeTransaction, transactionAccount } =
       await cryptidWithoutMiddleware.propose(makeTransaction());
-    await cryptidWithoutMiddleware.send(proposeTransaction, {
-      skipPreflight: true,
-    });
+    await cryptidWithoutMiddleware.send(
+      proposeTransaction,
+      [transactionAccount],
+      {
+        skipPreflight: true,
+      }
+    );
 
     // send the execute tx - this will fail since the middeware was not used
     const [executeTransaction] = await cryptidWithoutMiddleware.execute(
-      transactionAccountAddress
+      transactionAccount.publicKey
     );
-    const shouldFail = cryptidWithoutMiddleware.send(executeTransaction, {
+    const shouldFail = cryptidWithoutMiddleware.send(executeTransaction, [], {
       skipPreflight: true,
     });
 
@@ -127,8 +134,10 @@ describe("Middleware: checkRecipient", () => {
 
     // propose the Cryptid transaction. Since the checkRecipient middleware
     // executes on propose, this tx will fail
-    const { proposeTransaction } = await cryptid.propose(makeTransaction());
-    const shouldFail = cryptid.send(proposeTransaction, {
+    const { proposeTransaction, transactionAccount } = await cryptid.propose(
+      makeTransaction()
+    );
+    const shouldFail = cryptid.send(proposeTransaction, [transactionAccount], {
       skipPreflight: true,
     });
 

--- a/packages/tests/src/middleware/timeDelay.ts
+++ b/packages/tests/src/middleware/timeDelay.ts
@@ -103,14 +103,16 @@ describe("Middleware: timeDelay", () => {
 
   it("cannot immediately execute a transfer", async () => {
     // propose the Cryptid transaction
-    const { proposeTransaction, transactionAccount, signers } =
+    const { proposeTransaction, transactionAccount, proposeSigners } =
       await slowCryptid.propose(makeTransaction(slowCryptid));
 
-    await slowCryptid.send(proposeTransaction, signers);
+    await slowCryptid.send(proposeTransaction, proposeSigners);
 
     // send the execute tx, which fails to pass through the middleware
-    const [executeTransaction] = await slowCryptid.execute(transactionAccount);
-    const shouldFail = slowCryptid.send(executeTransaction);
+    const { executeTransactions, executeSigners } = await slowCryptid.execute(
+      transactionAccount
+    );
+    const shouldFail = slowCryptid.send(executeTransactions[0], executeSigners);
 
     // TODO expose the error message
     return expect(shouldFail).to.be.rejected;
@@ -120,16 +122,18 @@ describe("Middleware: timeDelay", () => {
     const previousBalance = await balanceOf(fastCryptid.address());
 
     // propose the Cryptid transaction
-    const { proposeTransaction, transactionAccount, signers } =
+    const { proposeTransaction, transactionAccount, proposeSigners } =
       await fastCryptid.propose(makeTransaction(fastCryptid));
-    await fastCryptid.send(proposeTransaction, signers);
+    await fastCryptid.send(proposeTransaction, proposeSigners);
 
     // wait for the transaction to be ready
     await sleep(2000);
 
     // execute the Cryptid transaction (passing the middleware)
-    const [executeTransaction] = await fastCryptid.execute(transactionAccount);
-    await fastCryptid.send(executeTransaction);
+    const { executeTransactions, executeSigners } = await fastCryptid.execute(
+      transactionAccount
+    );
+    await fastCryptid.send(executeTransactions[0], executeSigners);
 
     const currentBalance = await balanceOf(fastCryptid.address());
     expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed

--- a/packages/tests/src/middleware/timeDelay.ts
+++ b/packages/tests/src/middleware/timeDelay.ts
@@ -103,20 +103,14 @@ describe("Middleware: timeDelay", () => {
 
   it("cannot immediately execute a transfer", async () => {
     // propose the Cryptid transaction
-    const { proposeTransaction, transactionAccount } =
+    const { proposeTransaction, transactionAccount, signers } =
       await slowCryptid.propose(makeTransaction(slowCryptid));
 
-    await slowCryptid.send(proposeTransaction, [transactionAccount], {
-      skipPreflight: true,
-    });
+    await slowCryptid.send(proposeTransaction, signers);
 
     // send the execute tx, which fails to pass through the middleware
-    const [executeTransaction] = await slowCryptid.execute(
-      transactionAccount.publicKey
-    );
-    const shouldFail = slowCryptid.send(executeTransaction, {
-      skipPreflight: true,
-    });
+    const [executeTransaction] = await slowCryptid.execute(transactionAccount);
+    const shouldFail = slowCryptid.send(executeTransaction);
 
     // TODO expose the error message
     return expect(shouldFail).to.be.rejected;
@@ -126,22 +120,16 @@ describe("Middleware: timeDelay", () => {
     const previousBalance = await balanceOf(fastCryptid.address());
 
     // propose the Cryptid transaction
-    const { proposeTransaction, transactionAccount } =
+    const { proposeTransaction, transactionAccount, signers } =
       await fastCryptid.propose(makeTransaction(fastCryptid));
-    await fastCryptid.send(proposeTransaction, [transactionAccount], {
-      skipPreflight: true,
-    });
+    await fastCryptid.send(proposeTransaction, signers);
 
     // wait for the transaction to be ready
     await sleep(2000);
 
     // execute the Cryptid transaction (passing the middleware)
-    const [executeTransaction] = await fastCryptid.execute(
-      transactionAccount.publicKey
-    );
-    await fastCryptid.send(executeTransaction, [], {
-      skipPreflight: true,
-    });
+    const [executeTransaction] = await fastCryptid.execute(transactionAccount);
+    await fastCryptid.send(executeTransaction);
 
     const currentBalance = await balanceOf(fastCryptid.address());
     expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed

--- a/packages/tests/src/middleware/timeDelay.ts
+++ b/packages/tests/src/middleware/timeDelay.ts
@@ -103,14 +103,16 @@ describe("Middleware: timeDelay", () => {
 
   it("cannot immediately execute a transfer", async () => {
     // propose the Cryptid transaction
-    const { proposeTransaction, transactionAccountAddress } =
+    const { proposeTransaction, transactionAccount } =
       await slowCryptid.propose(makeTransaction(slowCryptid));
 
-    await slowCryptid.send(proposeTransaction, { skipPreflight: true });
+    await slowCryptid.send(proposeTransaction, [transactionAccount], {
+      skipPreflight: true,
+    });
 
     // send the execute tx, which fails to pass through the middleware
     const [executeTransaction] = await slowCryptid.execute(
-      transactionAccountAddress
+      transactionAccount.publicKey
     );
     const shouldFail = slowCryptid.send(executeTransaction, {
       skipPreflight: true,
@@ -124,18 +126,20 @@ describe("Middleware: timeDelay", () => {
     const previousBalance = await balanceOf(fastCryptid.address());
 
     // propose the Cryptid transaction
-    const { proposeTransaction, transactionAccountAddress } =
+    const { proposeTransaction, transactionAccount } =
       await fastCryptid.propose(makeTransaction(fastCryptid));
-    await fastCryptid.send(proposeTransaction, { skipPreflight: true });
+    await fastCryptid.send(proposeTransaction, [transactionAccount], {
+      skipPreflight: true,
+    });
 
     // wait for the transaction to be ready
     await sleep(2000);
 
     // execute the Cryptid transaction (passing the middleware)
     const [executeTransaction] = await fastCryptid.execute(
-      transactionAccountAddress
+      transactionAccount.publicKey
     );
-    await fastCryptid.send(executeTransaction, {
+    await fastCryptid.send(executeTransaction, [], {
       skipPreflight: true,
     });
 

--- a/packages/tests/src/proposeExecute.ts
+++ b/packages/tests/src/proposeExecute.ts
@@ -124,18 +124,22 @@ didTestCases.forEach(({ type, beforeFn }) => {
       const previousBalance = await balanceOf(cryptid.address());
 
       // send the propose tx
-      const { proposeTransaction, transactionAccountAddress } =
-        await cryptid.propose(makeTransaction());
-      await cryptid.send(proposeTransaction, { skipPreflight: true });
+      const { proposeTransaction, transactionAccount } = await cryptid.propose(
+        makeTransaction()
+      );
+
+      await cryptid.send(proposeTransaction, [transactionAccount], {
+        skipPreflight: true,
+      });
 
       let currentBalance = await balanceOf(cryptid.address());
       expect(previousBalance - currentBalance).to.equal(0); // Nothing has happened yet
 
       // send the execute tx
       const [executeTransaction] = await cryptid.execute(
-        transactionAccountAddress
+        transactionAccount.publicKey
       );
-      await cryptid.send(executeTransaction, { skipPreflight: true });
+      await cryptid.send(executeTransaction, [], { skipPreflight: true });
 
       currentBalance = await balanceOf(cryptid.address());
       expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed
@@ -194,11 +198,11 @@ didTestCases.forEach(({ type, beforeFn }) => {
     it("can propose and execute in the same transaction using the cryptid client", async () => {
       const previousBalance = await balanceOf(cryptid.address());
 
-      const [bigTransaction] = await cryptid.proposeAndExecute(
-        makeTransaction(),
-        true
-      );
-      await cryptid.send(bigTransaction, { skipPreflight: true });
+      const { proposeExecuteTransactions, transactionAccount } =
+        await cryptid.proposeAndExecute(makeTransaction(), true);
+      await cryptid.send(proposeExecuteTransactions[0], [transactionAccount], {
+        skipPreflight: true,
+      });
 
       const currentBalance = await balanceOf(cryptid.address());
       expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed

--- a/packages/tests/src/proposeExecute.ts
+++ b/packages/tests/src/proposeExecute.ts
@@ -30,6 +30,8 @@ didTestCases.forEach(({ type, beforeFn }) => {
     const { program, provider, authority, keypair } = createTestContext();
 
     let didAccount: PublicKey;
+    let didAccountBump: number;
+
     let cryptidBump: number;
 
     const recipient = Keypair.generate();
@@ -68,6 +70,7 @@ didTestCases.forEach(({ type, beforeFn }) => {
         .executeTransaction(
           Buffer.from([]), // no controller chain,
           cryptidBump,
+          didAccountBump,
           0
         )
         .accounts({
@@ -86,7 +89,7 @@ didTestCases.forEach(({ type, beforeFn }) => {
 
     before("Set up DID account", async () => {
       await fund(authority.publicKey, 10 * LAMPORTS_PER_SOL);
-      didAccount = await beforeFn(authority);
+      [didAccount, didAccountBump] = await beforeFn(authority);
     });
 
     // TODO: Once the new anchor "default value" macro is available, switch this back to using a generative cryptid account
@@ -163,6 +166,7 @@ didTestCases.forEach(({ type, beforeFn }) => {
         .executeTransaction(
           Buffer.from([]), // no controller chain
           cryptidBump,
+          didAccountBump,
           0
         )
         .accounts({
@@ -286,6 +290,7 @@ didTestCases.forEach(({ type, beforeFn }) => {
         .executeTransaction(
           Buffer.from([]), // no controller chain
           cryptidBump,
+          didAccountBump,
           0
         )
         .accounts({

--- a/packages/tests/src/proposeExecute.ts
+++ b/packages/tests/src/proposeExecute.ts
@@ -323,7 +323,7 @@ didTestCases.forEach(({ didType, getDidAccount }) => {
             cryptidAccount: cryptid.address(),
             didProgram: DID_SOL_PROGRAM,
             did: didAccount,
-            authority: bogusSigner.publicKey,  // specify the bogus signer as the authority
+            authority: bogusSigner.publicKey, // specify the bogus signer as the authority
             transactionAccount: transactionAccount.publicKey,
           })
           .remainingAccounts([

--- a/packages/tests/src/proposeExecute.ts
+++ b/packages/tests/src/proposeExecute.ts
@@ -129,17 +129,19 @@ didTestCases.forEach(({ didType, getDidAccount }) => {
         const previousBalance = await balanceOf(cryptid.address());
 
         // send the propose tx
-        const { proposeTransaction, transactionAccount, signers } =
+        const { proposeTransaction, transactionAccount, proposeSigners } =
           await cryptid.propose(makeTransaction());
 
-        await cryptid.send(proposeTransaction, signers);
+        await cryptid.send(proposeTransaction, proposeSigners);
 
         let currentBalance = await balanceOf(cryptid.address());
         expect(previousBalance - currentBalance).to.equal(0); // Nothing has happened yet
 
         // send the execute tx
-        const [executeTransaction] = await cryptid.execute(transactionAccount);
-        await cryptid.send(executeTransaction);
+        const { executeTransactions } = await cryptid.execute(
+          transactionAccount
+        );
+        await cryptid.send(executeTransactions[0]);
 
         currentBalance = await balanceOf(cryptid.address());
         expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed
@@ -210,9 +212,9 @@ didTestCases.forEach(({ didType, getDidAccount }) => {
       it("can propose and execute in the same transaction using the cryptid client", async () => {
         const previousBalance = await balanceOf(cryptid.address());
 
-        const { proposeExecuteTransactions, signers } =
+        const { executeTransactions, executeSigners } =
           await cryptid.proposeAndExecute(makeTransaction(), true);
-        await cryptid.send(proposeExecuteTransactions[0], signers);
+        await cryptid.send(executeTransactions[0], executeSigners);
 
         const currentBalance = await balanceOf(cryptid.address());
         expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed

--- a/packages/tests/src/proposeExecute.ts
+++ b/packages/tests/src/proposeExecute.ts
@@ -53,7 +53,7 @@ didTestCases.forEach(({ type, beforeFn }) => {
         .proposeTransaction([instruction], 2)
         .accounts({
           cryptidAccount: cryptid.address(),
-          owner: didAccount,
+          did: didAccount,
           authority: authority.publicKey,
           transactionAccount: transactionAccount.publicKey,
         })
@@ -155,7 +155,7 @@ didTestCases.forEach(({ type, beforeFn }) => {
         .proposeTransaction([transferInstructionData], 2)
         .accounts({
           cryptidAccount: cryptid.address(),
-          owner: didAccount,
+          did: didAccount,
           authority: authority.publicKey,
           transactionAccount: transactionAccount.publicKey,
         })

--- a/packages/tests/src/proposeExecute.ts
+++ b/packages/tests/src/proposeExecute.ts
@@ -50,6 +50,8 @@ didTestCases.forEach(({ didType, getDidAccount }) => {
         program.methods
           .proposeTransaction(
             Buffer.from([]), // no controller chain,
+            cryptid.details.bump,
+            cryptid.details.index,
             cryptid.details.didAccountBump,
             [instruction],
             2
@@ -127,21 +129,17 @@ didTestCases.forEach(({ didType, getDidAccount }) => {
         const previousBalance = await balanceOf(cryptid.address());
 
         // send the propose tx
-        const { proposeTransaction, transactionAccount } =
+        const { proposeTransaction, transactionAccount, signers } =
           await cryptid.propose(makeTransaction());
 
-        await cryptid.send(proposeTransaction, [transactionAccount], {
-          skipPreflight: true,
-        });
+        await cryptid.send(proposeTransaction, signers);
 
         let currentBalance = await balanceOf(cryptid.address());
         expect(previousBalance - currentBalance).to.equal(0); // Nothing has happened yet
 
         // send the execute tx
-        const [executeTransaction] = await cryptid.execute(
-          transactionAccount.publicKey
-        );
-        await cryptid.send(executeTransaction, [], { skipPreflight: true });
+        const [executeTransaction] = await cryptid.execute(transactionAccount);
+        await cryptid.send(executeTransaction);
 
         currentBalance = await balanceOf(cryptid.address());
         expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed
@@ -156,6 +154,8 @@ didTestCases.forEach(({ didType, getDidAccount }) => {
         const proposeIx = await program.methods
           .proposeTransaction(
             Buffer.from([]), // no controller chain,
+            cryptid.details.bump,
+            cryptid.details.index,
             cryptid.details.didAccountBump,
             [transferInstructionData],
             2
@@ -210,15 +210,9 @@ didTestCases.forEach(({ didType, getDidAccount }) => {
       it("can propose and execute in the same transaction using the cryptid client", async () => {
         const previousBalance = await balanceOf(cryptid.address());
 
-        const { proposeExecuteTransactions, transactionAccount } =
+        const { proposeExecuteTransactions, signers } =
           await cryptid.proposeAndExecute(makeTransaction(), true);
-        await cryptid.send(
-          proposeExecuteTransactions[0],
-          [transactionAccount],
-          {
-            skipPreflight: true,
-          }
-        );
+        await cryptid.send(proposeExecuteTransactions[0], signers);
 
         const currentBalance = await balanceOf(cryptid.address());
         expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed
@@ -315,6 +309,8 @@ didTestCases.forEach(({ didType, getDidAccount }) => {
         const shouldFail = program.methods
           .proposeTransaction(
             Buffer.from([]), // no controller chain,
+            cryptid.details.bump,
+            cryptid.details.index,
             cryptid.details.didAccountBump,
             [transferInstructionData],
             2

--- a/packages/tests/src/proposeExecute.ts
+++ b/packages/tests/src/proposeExecute.ts
@@ -7,14 +7,14 @@ import {
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import {
-  createCryptid,
+  cryptidTestCases,
   cryptidTransferInstruction,
   makeTransfer,
   toAccountMeta,
 } from "./util/cryptid";
 import { didTestCases } from "./util/did";
 import { fund, createTestContext, balanceOf } from "./util/anchorUtils";
-import { DID_SOL_PROGRAM } from "@identity.com/sol-did-client";
+import { DID_SOL_PREFIX, DID_SOL_PROGRAM } from "@identity.com/sol-did-client";
 import { web3 } from "@project-serum/anchor";
 import {
   CryptidClient,
@@ -25,297 +25,309 @@ import {
 chai.use(chaiAsPromised);
 const { expect } = chai;
 
-didTestCases.forEach(({ type, beforeFn }) => {
-  describe(`proposeExecute (${type})`, () => {
-    const { program, provider, authority, keypair } = createTestContext();
+didTestCases.forEach(({ didType, getDidAccount }) => {
+  cryptidTestCases.forEach(({ cryptidType, getCryptidClient }) => {
+    describe(`proposeExecute (${didType} DID, ${cryptidType} Cryptid)`, () => {
+      const { program, provider, authority, keypair } = createTestContext();
+      let didAccount: PublicKey;
+      const did = DID_SOL_PREFIX + ":" + authority.publicKey;
 
-    let didAccount: PublicKey;
-    let didAccountBump: number;
+      const recipient = Keypair.generate();
 
-    let cryptidBump: number;
+      let cryptid: CryptidClient;
 
-    const recipient = Keypair.generate();
-
-    let cryptid: CryptidClient;
-
-    // use this when testing directly against anchor
-    const transferInstructionData =
-      cryptidTransferInstruction(LAMPORTS_PER_SOL); // 1 SOL
-    // use this when testing against the cryptid client
-    const makeTransaction = () =>
-      makeTransfer(cryptid.address(), recipient.publicKey);
-
-    const propose = async (
-      transactionAccount: Keypair,
-      instruction: InstructionData = transferInstructionData
-    ) =>
-      program.methods
-        .proposeTransaction([instruction], 2)
-        .accounts({
-          cryptidAccount: cryptid.address(),
-          did: didAccount,
-          authority: authority.publicKey,
-          transactionAccount: transactionAccount.publicKey,
-        })
-        .remainingAccounts([
-          toAccountMeta(recipient.publicKey, true, false),
-          toAccountMeta(SystemProgram.programId),
-        ])
-        .signers([transactionAccount])
-        .rpc({ skipPreflight: true }); // skip preflight so we see validator logs on error
-
-    const execute = (transactionAccount: Keypair) =>
-      // execute the Cryptid transaction
-      program.methods
-        .executeTransaction(
-          Buffer.from([]), // no controller chain,
-          cryptidBump,
-          didAccountBump,
-          0
-        )
-        .accounts({
-          cryptidAccount: cryptid.address(),
-          didProgram: DID_SOL_PROGRAM,
-          did: didAccount,
-          signer: authority.publicKey,
-          destination: authority.publicKey,
-          transactionAccount: transactionAccount.publicKey,
-        })
-        .remainingAccounts([
-          toAccountMeta(recipient.publicKey, true, false),
-          toAccountMeta(SystemProgram.programId),
-        ])
-        .rpc({ skipPreflight: true }); // skip preflight so we see validator logs on error
-
-    before("Set up DID account", async () => {
-      await fund(authority.publicKey, 10 * LAMPORTS_PER_SOL);
-      [didAccount, didAccountBump] = await beforeFn(authority);
-    });
-
-    // TODO: Once the new anchor "default value" macro is available, switch this back to using a generative cryptid account
-    // For now, Propose/Execute requires non-generative accounts, so we can check for the presence of a registered middleware
-    before("Set up a Cryptid Account", async () => {
-      cryptid = await createCryptid(authority, {
-        connection: provider.connection,
-      });
-
-      await fund(cryptid.address(), 20 * LAMPORTS_PER_SOL);
-    });
-
-    it("can propose and execute a transfer through Cryptid", async () => {
-      const previousBalance = await balanceOf(cryptid.address());
-
-      const transactionAccount = Keypair.generate();
-
-      // propose the Cryptid transaction
-      await propose(transactionAccount);
-
-      let currentBalance = await balanceOf(cryptid.address());
-      expect(previousBalance - currentBalance).to.equal(0); // Nothing has happened yet
-
-      // execute the Cryptid transaction
-      await execute(transactionAccount);
-
-      currentBalance = await balanceOf(cryptid.address());
-      expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed
-    });
-
-    it("can propose and execute a transfer using the Cryptid client", async () => {
-      const previousBalance = await balanceOf(cryptid.address());
-
-      // send the propose tx
-      const { proposeTransaction, transactionAccount } = await cryptid.propose(
-        makeTransaction()
-      );
-
-      await cryptid.send(proposeTransaction, [transactionAccount], {
-        skipPreflight: true,
-      });
-
-      let currentBalance = await balanceOf(cryptid.address());
-      expect(previousBalance - currentBalance).to.equal(0); // Nothing has happened yet
-
-      // send the execute tx
-      const [executeTransaction] = await cryptid.execute(
-        transactionAccount.publicKey
-      );
-      await cryptid.send(executeTransaction, [], { skipPreflight: true });
-
-      currentBalance = await balanceOf(cryptid.address());
-      expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed
-    });
-
-    it("can propose and execute in the same transaction", async () => {
-      const previousBalance = await balanceOf(cryptid.address());
-
-      const transactionAccount = Keypair.generate();
-
-      // propose the Cryptid transaction
-      const proposeIx = await program.methods
-        .proposeTransaction([transferInstructionData], 2)
-        .accounts({
-          cryptidAccount: cryptid.address(),
-          did: didAccount,
-          authority: authority.publicKey,
-          transactionAccount: transactionAccount.publicKey,
-        })
-        .remainingAccounts([
-          toAccountMeta(recipient.publicKey, true, false),
-          toAccountMeta(SystemProgram.programId),
-        ])
-        .signers([transactionAccount])
-        .instruction();
-
-      const executeIx = await program.methods
-        .executeTransaction(
-          Buffer.from([]), // no controller chain
-          cryptidBump,
-          didAccountBump,
-          0
-        )
-        .accounts({
-          cryptidAccount: cryptid.address(),
-          didProgram: DID_SOL_PROGRAM,
-          did: didAccount,
-          signer: authority.publicKey,
-          destination: authority.publicKey,
-          transactionAccount: transactionAccount.publicKey,
-        })
-        .remainingAccounts([
-          toAccountMeta(recipient.publicKey, true, false),
-          toAccountMeta(SystemProgram.programId),
-        ])
-        .instruction();
-
-      const transaction = new web3.Transaction().add(proposeIx, executeIx);
-
-      await provider.sendAndConfirm(transaction, [keypair, transactionAccount]);
-
-      const currentBalance = await balanceOf(cryptid.address());
-      expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed
-    });
-
-    it("can propose and execute in the same transaction using the cryptid client", async () => {
-      const previousBalance = await balanceOf(cryptid.address());
-
-      const { proposeExecuteTransactions, transactionAccount } =
-        await cryptid.proposeAndExecute(makeTransaction(), true);
-      await cryptid.send(proposeExecuteTransactions[0], [transactionAccount], {
-        skipPreflight: true,
-      });
-
-      const currentBalance = await balanceOf(cryptid.address());
-      expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed
-    });
-
-    it("can reuse the same transfer account", async () => {
-      const previousBalance = await balanceOf(cryptid.address());
-
-      const transactionAccount = Keypair.generate();
-
-      // Propose & execute once
-      await propose(transactionAccount);
-      await execute(transactionAccount);
-
-      // Propose & execute twice
-      await propose(transactionAccount);
-      await execute(transactionAccount);
-
-      const currentBalance = await balanceOf(cryptid.address());
-
-      // The tx has been executed twice
-      // Note - this is not a double-spend, as the tx has to be proposed twice
-      expect(previousBalance - currentBalance).to.equal(2 * LAMPORTS_PER_SOL);
-    });
-
-    it("cannot re-execute the same proposed transfer", async () => {
-      const previousBalance = await balanceOf(cryptid.address());
-
-      const transactionAccount = Keypair.generate();
-
-      // Propose & execute
-      await propose(transactionAccount);
-      await execute(transactionAccount);
-
-      // cannot re-execute
-      const shouldFail = execute(transactionAccount);
-
-      const currentBalance = await balanceOf(cryptid.address());
-
-      // The tx has been executed once only
-      expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL);
-
-      // TODO expose the error message
-      return expect(shouldFail).to.be.rejected;
-    });
-
-    it("rejects the execution if the cryptid account is not a signer", async () => {
-      const transactionAccount = Keypair.generate();
-
-      const instructionDataWithUnauthorisedSigner =
+      // use this when testing directly against anchor
+      const transferInstructionData =
         cryptidTransferInstruction(LAMPORTS_PER_SOL); // 1 SOL
-      // set the cryptid account as a non-signer on the transfer
-      (
-        instructionDataWithUnauthorisedSigner.accounts as TransactionAccountMeta[]
-      )[0].meta = 2; // writable but not a signer
+      // use this when testing against the cryptid client
+      const makeTransaction = () =>
+        makeTransfer(cryptid.address(), recipient.publicKey);
 
-      await propose(transactionAccount, instructionDataWithUnauthorisedSigner);
-      const shouldFail = execute(transactionAccount);
+      const propose = async (
+        transactionAccount: Keypair,
+        instruction: InstructionData = transferInstructionData
+      ) =>
+        program.methods
+          .proposeTransaction([instruction], 2)
+          .accounts({
+            cryptidAccount: cryptid.address(),
+            did: didAccount,
+            authority: authority.publicKey,
+            transactionAccount: transactionAccount.publicKey,
+          })
+          .remainingAccounts([
+            toAccountMeta(recipient.publicKey, true, false),
+            toAccountMeta(SystemProgram.programId),
+          ])
+          .signers([transactionAccount])
+          .rpc({ skipPreflight: true }); // skip preflight so we see validator logs on error
 
-      // TODO expose the error message
-      return expect(shouldFail).to.be.rejected;
-    });
+      const execute = (transactionAccount: Keypair) =>
+        // execute the Cryptid transaction
+        program.methods
+          .executeTransaction(
+            Buffer.from([]), // no controller chain,
+            cryptid.details.bump,
+            cryptid.details.index,
+            cryptid.details.didAccountBump,
+            0
+          )
+          .accounts({
+            cryptidAccount: cryptid.address(),
+            didProgram: DID_SOL_PROGRAM,
+            did: didAccount,
+            signer: authority.publicKey,
+            destination: authority.publicKey,
+            transactionAccount: transactionAccount.publicKey,
+          })
+          .remainingAccounts([
+            toAccountMeta(recipient.publicKey, true, false),
+            toAccountMeta(SystemProgram.programId),
+          ])
+          .rpc({ skipPreflight: true }); // skip preflight so we see validator logs on error
 
-    it("rejects the execution if the recipient account index is invalid", async () => {
-      const transactionAccount = Keypair.generate();
+      before(`Set up ${didType} DID account`, async () => {
+        await fund(authority.publicKey, 10 * LAMPORTS_PER_SOL);
+        [didAccount] = await getDidAccount(authority);
+      });
 
-      const instructionDataWithInvalidAccountIndex =
-        cryptidTransferInstruction(LAMPORTS_PER_SOL); // 1 SOL
-      // set the recipient account as an invalid account index
-      (
-        instructionDataWithInvalidAccountIndex.accounts as TransactionAccountMeta[]
-      )[1].key = 100; // account 100 does not exist
+      before(`Set up a ${cryptidType} Cryptid Account`, async () => {
+        cryptid = await getCryptidClient(did, authority, {
+          connection: provider.connection,
+        });
 
-      // TODO this should fail on propose
-      await propose(transactionAccount, instructionDataWithInvalidAccountIndex);
-      const shouldFail = execute(transactionAccount);
+        await fund(cryptid.address(), 20 * LAMPORTS_PER_SOL);
+      });
 
-      return expect(shouldFail).to.be.rejectedWith(/ProgramFailedToComplete/);
-    });
+      it("can propose and execute a transfer through Cryptid", async () => {
+        const previousBalance = await balanceOf(cryptid.address());
 
-    it("rejects the transfer if the signer is not a valid signer on the DID", async () => {
-      const transactionAccount = Keypair.generate();
+        const transactionAccount = Keypair.generate();
 
-      const bogusSigner = Keypair.generate();
+        // propose the Cryptid transaction
+        await propose(transactionAccount);
 
-      await propose(transactionAccount);
-      // execute the Cryptid transaction
-      const shouldFail = program.methods
-        .executeTransaction(
-          Buffer.from([]), // no controller chain
-          cryptidBump,
-          didAccountBump,
-          0
-        )
-        .accounts({
-          cryptidAccount: cryptid.address(),
-          didProgram: DID_SOL_PROGRAM,
-          did: didAccount,
-          signer: bogusSigner.publicKey, // specify the bogus signer as the cryptid signer
-          destination: authority.publicKey,
-          transactionAccount: transactionAccount.publicKey,
-        })
-        .remainingAccounts([
-          toAccountMeta(recipient.publicKey, true, false),
-          toAccountMeta(SystemProgram.programId),
-        ])
-        .signers(
-          [bogusSigner] // sign with the bogus signer
-        )
-        .rpc({ skipPreflight: true }); // skip preflight so we see validator logs on error
+        let currentBalance = await balanceOf(cryptid.address());
+        expect(previousBalance - currentBalance).to.equal(0); // Nothing has happened yet
 
-      // TODO expose the error from the program
-      return expect(shouldFail).to.be.rejected;
+        // execute the Cryptid transaction
+        await execute(transactionAccount);
+
+        currentBalance = await balanceOf(cryptid.address());
+        expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed
+      });
+
+      it("can propose and execute a transfer using the Cryptid client", async () => {
+        const previousBalance = await balanceOf(cryptid.address());
+
+        // send the propose tx
+        const { proposeTransaction, transactionAccount } =
+          await cryptid.propose(makeTransaction());
+
+        await cryptid.send(proposeTransaction, [transactionAccount], {
+          skipPreflight: true,
+        });
+
+        let currentBalance = await balanceOf(cryptid.address());
+        expect(previousBalance - currentBalance).to.equal(0); // Nothing has happened yet
+
+        // send the execute tx
+        const [executeTransaction] = await cryptid.execute(
+          transactionAccount.publicKey
+        );
+        await cryptid.send(executeTransaction, [], { skipPreflight: true });
+
+        currentBalance = await balanceOf(cryptid.address());
+        expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed
+      });
+
+      it("can propose and execute in the same transaction", async () => {
+        const previousBalance = await balanceOf(cryptid.address());
+
+        const transactionAccount = Keypair.generate();
+
+        // propose the Cryptid transaction
+        const proposeIx = await program.methods
+          .proposeTransaction([transferInstructionData], 2)
+          .accounts({
+            cryptidAccount: cryptid.address(),
+            did: didAccount,
+            authority: authority.publicKey,
+            transactionAccount: transactionAccount.publicKey,
+          })
+          .remainingAccounts([
+            toAccountMeta(recipient.publicKey, true, false),
+            toAccountMeta(SystemProgram.programId),
+          ])
+          .signers([transactionAccount])
+          .instruction();
+
+        const executeIx = await program.methods
+          .executeTransaction(
+            Buffer.from([]), // no controller chain
+            cryptid.details.bump,
+            cryptid.details.index,
+            cryptid.details.didAccountBump,
+            0
+          )
+          .accounts({
+            cryptidAccount: cryptid.address(),
+            didProgram: DID_SOL_PROGRAM,
+            did: didAccount,
+            signer: authority.publicKey,
+            destination: authority.publicKey,
+            transactionAccount: transactionAccount.publicKey,
+          })
+          .remainingAccounts([
+            toAccountMeta(recipient.publicKey, true, false),
+            toAccountMeta(SystemProgram.programId),
+          ])
+          .instruction();
+
+        const transaction = new web3.Transaction().add(proposeIx, executeIx);
+
+        await provider.sendAndConfirm(transaction, [
+          keypair,
+          transactionAccount,
+        ]);
+
+        const currentBalance = await balanceOf(cryptid.address());
+        expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed
+      });
+
+      it("can propose and execute in the same transaction using the cryptid client", async () => {
+        const previousBalance = await balanceOf(cryptid.address());
+
+        const { proposeExecuteTransactions, transactionAccount } =
+          await cryptid.proposeAndExecute(makeTransaction(), true);
+        await cryptid.send(
+          proposeExecuteTransactions[0],
+          [transactionAccount],
+          {
+            skipPreflight: true,
+          }
+        );
+
+        const currentBalance = await balanceOf(cryptid.address());
+        expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed
+      });
+
+      it("can reuse the same transfer account", async () => {
+        const previousBalance = await balanceOf(cryptid.address());
+
+        const transactionAccount = Keypair.generate();
+
+        // Propose & execute once
+        await propose(transactionAccount);
+        await execute(transactionAccount);
+
+        // Propose & execute twice
+        await propose(transactionAccount);
+        await execute(transactionAccount);
+
+        const currentBalance = await balanceOf(cryptid.address());
+
+        // The tx has been executed twice
+        // Note - this is not a double-spend, as the tx has to be proposed twice
+        expect(previousBalance - currentBalance).to.equal(2 * LAMPORTS_PER_SOL);
+      });
+
+      it("cannot re-execute the same proposed transfer", async () => {
+        const previousBalance = await balanceOf(cryptid.address());
+
+        const transactionAccount = Keypair.generate();
+
+        // Propose & execute
+        await propose(transactionAccount);
+        await execute(transactionAccount);
+
+        // cannot re-execute
+        const shouldFail = execute(transactionAccount);
+
+        const currentBalance = await balanceOf(cryptid.address());
+
+        // The tx has been executed once only
+        expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL);
+
+        // TODO expose the error message
+        return expect(shouldFail).to.be.rejected;
+      });
+
+      it("rejects the execution if the cryptid account is not a signer", async () => {
+        const transactionAccount = Keypair.generate();
+
+        const instructionDataWithUnauthorisedSigner =
+          cryptidTransferInstruction(LAMPORTS_PER_SOL); // 1 SOL
+        // set the cryptid account as a non-signer on the transfer
+        (
+          instructionDataWithUnauthorisedSigner.accounts as TransactionAccountMeta[]
+        )[0].meta = 2; // writable but not a signer
+
+        await propose(
+          transactionAccount,
+          instructionDataWithUnauthorisedSigner
+        );
+        const shouldFail = execute(transactionAccount);
+
+        // TODO expose the error message
+        return expect(shouldFail).to.be.rejected;
+      });
+
+      it("rejects the execution if the recipient account index is invalid", async () => {
+        const transactionAccount = Keypair.generate();
+
+        const instructionDataWithInvalidAccountIndex =
+          cryptidTransferInstruction(LAMPORTS_PER_SOL); // 1 SOL
+        // set the recipient account as an invalid account index
+        (
+          instructionDataWithInvalidAccountIndex.accounts as TransactionAccountMeta[]
+        )[1].key = 100; // account 100 does not exist
+
+        // TODO this should fail on propose
+        await propose(
+          transactionAccount,
+          instructionDataWithInvalidAccountIndex
+        );
+        const shouldFail = execute(transactionAccount);
+
+        return expect(shouldFail).to.be.rejectedWith(/ProgramFailedToComplete/);
+      });
+
+      it("rejects the transfer if the signer is not a valid signer on the DID", async () => {
+        const transactionAccount = Keypair.generate();
+
+        const bogusSigner = Keypair.generate();
+
+        await propose(transactionAccount);
+        // execute the Cryptid transaction
+        const shouldFail = program.methods
+          .executeTransaction(
+            Buffer.from([]), // no controller chain
+            cryptid.details.bump,
+            cryptid.details.index,
+            cryptid.details.didAccountBump,
+            0
+          )
+          .accounts({
+            cryptidAccount: cryptid.address(),
+            didProgram: DID_SOL_PROGRAM,
+            did: didAccount,
+            signer: bogusSigner.publicKey, // specify the bogus signer as the cryptid signer
+            destination: authority.publicKey,
+            transactionAccount: transactionAccount.publicKey,
+          })
+          .remainingAccounts([
+            toAccountMeta(recipient.publicKey, true, false),
+            toAccountMeta(SystemProgram.programId),
+          ])
+          .signers(
+            [bogusSigner] // sign with the bogus signer
+          )
+          .rpc({ skipPreflight: true }); // skip preflight so we see validator logs on error
+
+        // TODO expose the error from the program
+        return expect(shouldFail).to.be.rejected;
+      });
     });
   });
 });

--- a/packages/tests/src/util/cryptid.ts
+++ b/packages/tests/src/util/cryptid.ts
@@ -1,5 +1,6 @@
 import {
   AccountMeta,
+  Keypair,
   LAMPORTS_PER_SOL,
   PublicKey,
   SystemProgram,
@@ -24,6 +25,7 @@ import BN from "bn.js";
 import { Program } from "@project-serum/anchor";
 import { Cryptid } from "@identity.com/cryptid-idl";
 import { Wallet } from "./anchorUtils";
+import { TestType } from "./did";
 
 export const toAccountMeta = (
   publicKey: PublicKey,
@@ -185,6 +187,35 @@ export const createCryptid = async (
     [],
     options
   );
+
+export const buildCryptid = async (
+  authority: Wallet,
+  options: CryptidOptions
+): Promise<CryptidClient> =>
+  await Builder.buildFromDID(
+    DID_SOL_PREFIX + ":" + authority.publicKey,
+    authority,
+    options
+  );
+
+export const cryptidTestCases = [
+  {
+    cryptidType: TestType.Generative,
+    getCryptidClient: async (
+      did: string,
+      authority: Wallet | Keypair,
+      options: CryptidOptions
+    ) => Builder.buildFromDID(did, authority, options),
+  },
+  {
+    cryptidType: TestType.Initialized,
+    getCryptidClient: async (
+      did: string,
+      authority: Wallet | Keypair,
+      options: CryptidOptions
+    ) => Builder.createFromDID(did, authority, [], options),
+  },
+];
 
 // use this when testing against the cryptid client
 export const makeTransfer = (from: PublicKey, to: PublicKey): Transaction =>

--- a/packages/tests/src/util/cryptid.ts
+++ b/packages/tests/src/util/cryptid.ts
@@ -148,22 +148,26 @@ export const deriveTimeDelayTransactionStateMiddlewareAccountAddress = (
 
 export const createCryptidAccount = async (
   program: Program<Cryptid>,
-  did: PublicKey,
+  didAccount: PublicKey,
+  didAccountBump: number,
   middlewareAccount?: PublicKey,
   index = 0
 ): Promise<[PublicKey, number]> => {
-  const [cryptidAccount, cryptidBump] = deriveCryptidAccountAddress(did, index);
+  const [cryptidAccount, cryptidBump] = deriveCryptidAccountAddress(
+    didAccount,
+    index
+  );
 
   await program.methods
     .create(
       middlewareAccount || null, // anchor requires null instead of undefined
       index,
-      cryptidBump
+      didAccountBump
     )
     .accounts({
       cryptidAccount,
       didProgram: DID_SOL_PROGRAM,
-      did,
+      did: didAccount,
       authority: program.provider.publicKey,
     })
     .rpc({ skipPreflight: true });

--- a/packages/tests/src/util/did.ts
+++ b/packages/tests/src/util/did.ts
@@ -42,19 +42,19 @@ export const getDidAccount = async (
   return did.dataAccount();
 };
 
-export enum DidTestType {
-  Generative = "generative DID",
-  Initialized = "initialized DID",
+export enum TestType {
+  Generative = "generative",
+  Initialized = "non-generative",
 }
 
 export const didTestCases = [
   {
-    type: DidTestType.Generative,
-    beforeFn: async (authority: Wallet) => await getDidAccount(authority),
+    didType: TestType.Generative,
+    getDidAccount: async (authority: Wallet) => await getDidAccount(authority),
   },
   {
-    type: DidTestType.Initialized,
-    beforeFn: async (authority: Wallet) =>
+    didType: TestType.Initialized,
+    getDidAccount: async (authority: Wallet) =>
       await initializeDIDAccount(authority),
   },
 ];

--- a/packages/tests/src/util/did.ts
+++ b/packages/tests/src/util/did.ts
@@ -25,19 +25,21 @@ export const addKeyToDID = async (authority: Wallet, key: PublicKey) => {
 
 export const initializeDIDAccount = async (
   authority: Wallet
-): Promise<PublicKey> => {
+): Promise<[PublicKey, number]> => {
   const did = DidSolIdentifier.create(authority.publicKey, CLUSTER);
   const didSolService = await DidSolService.build(did, {
     wallet: authority,
   });
 
   await didSolService.initialize(10_000).rpc();
-  return did.dataAccount()[0];
+  return did.dataAccount();
 };
 
-export const getDidAccount = async (authority: Wallet): Promise<PublicKey> => {
+export const getDidAccount = async (
+  authority: Wallet
+): Promise<[PublicKey, number]> => {
   const did = DidSolIdentifier.create(authority.publicKey, CLUSTER);
-  return did.dataAccount()[0];
+  return did.dataAccount();
 };
 
 export enum DidTestType {

--- a/programs/cryptid/src/error.rs
+++ b/programs/cryptid/src/error.rs
@@ -15,7 +15,7 @@ pub enum CryptidError {
     #[msg("Wrong DID program")]
     WrongDIDProgram,
     /// Wrong Cryptid account passed
-    #[msg("Wrong Cryptid account program")]
+    #[msg("A wrong Cryptid account was passed")]
     WrongCryptidAccount,
     /// Sub-instruction threw an error
     #[msg("Error in sub-instruction")]
@@ -26,9 +26,6 @@ pub enum CryptidError {
     /// An account in the transaction accounts did not match what was expected
     #[msg("An account in the transaction accounts did not match what was expected")]
     AccountMismatch,
-    /// Key is not a proposer for the transaction
-    #[msg("Key is not a proposer for the transaction")]
-    KeyCannotChangeTransaction,
     /// Signer is not authorised to sign for this Cryptid account
     #[msg("Signer is not authorised to sign for this Cryptid account")]
     KeyMustBeSigner,

--- a/programs/cryptid/src/instructions/create.rs
+++ b/programs/cryptid/src/instructions/create.rs
@@ -10,8 +10,8 @@ use anchor_lang::prelude::*;
 middleware: Option<Pubkey>,
 /// The index of this cryptid account - allows multiple cryptid accounts per DID
 index: u32,
-/// The bump seed for the cryptid account
-bump: u8,
+/// The bump seed for the Did Account
+did_account_bump: u8,
 )]
 pub struct Create<'info> {
     #[account(
@@ -19,7 +19,7 @@ pub struct Create<'info> {
     payer = authority,
     space = 8 + CryptidAccount::MAX_SIZE,
     seeds = [CryptidAccount::SEED_PREFIX, did_program.key().as_ref(), did.key().as_ref(), index.to_le_bytes().as_ref()],
-    bump
+    bump,
     )]
     pub cryptid_account: Account<'info, CryptidAccount>,
     /// The program for the DID
@@ -37,7 +37,7 @@ pub fn create(
     ctx: Context<Create>,
     middleware: Option<Pubkey>,
     index: u32,
-    _bump: u8,
+    did_account_bump: u8,
 ) -> Result<()> {
     require_gt!(index, 0, CryptidError::CreatingWithZeroIndex);
     ctx.accounts.cryptid_account.middleware = middleware;
@@ -52,6 +52,7 @@ pub fn create(
     // We now need to verify that the signer (at the moment, only one is supported) is a valid signer for the cryptid account
     verify_keys(
         &ctx.accounts.did,
+        Some(did_account_bump),
         ctx.accounts.authority.to_account_info().key,
         controlling_did_accounts,
     )?;

--- a/programs/cryptid/src/instructions/direct_execute.rs
+++ b/programs/cryptid/src/instructions/direct_execute.rs
@@ -13,7 +13,7 @@ controller_chain: Vec<u8>,
 instructions: Vec<AbbreviatedInstructionData>,
 /// The bump seed for the Cryptid signer
 cryptid_account_bump: u8,
-/// CryptidAccountIndex
+/// Index of the cryptid account
 cryptid_account_index: u32,
 /// The bump seed for the Did Account
 did_account_bump: u8,

--- a/programs/cryptid/src/instructions/direct_execute.rs
+++ b/programs/cryptid/src/instructions/direct_execute.rs
@@ -23,7 +23,12 @@ flags: u8,
 pub struct DirectExecute<'info> {
     /// The Cryptid instance to execute with
     /// CHECK: Cryptid Account can be generative and non-generative
-    #[account(mut)]
+    #[account(
+        mut,
+        // TODO: Verification dones in instruction body. Move back with Anchor generator
+        // seeds = [CryptidAccount::SEED_PREFIX, did_program.key().as_ref(), did.key().as_ref(), cryptid_account_index.to_le_bytes().as_ref()],
+        // bump = cryptid_account_bump
+    )]
     pub cryptid_account: UncheckedAccount<'info>,
     /// The DID on the Cryptid instance
     /// CHECK: DID Account can be generative or not

--- a/programs/cryptid/src/instructions/direct_execute.rs
+++ b/programs/cryptid/src/instructions/direct_execute.rs
@@ -13,6 +13,8 @@ controller_chain: Vec<u8>,
 instructions: Vec<AbbreviatedInstructionData>,
 /// The bump seed for the Cryptid signer
 cryptid_account_bump: u8,
+/// The bump seed for the Did Account
+did_account_bump: u8,
 /// Additional flags
 flags: u8,
 )]
@@ -65,6 +67,7 @@ pub fn direct_execute<'a, 'b, 'c, 'info>(
     controller_chain: Vec<u8>,
     instructions: Vec<AbbreviatedInstructionData>,
     cryptid_account_bump: u8,
+    did_account_bump: u8,
     flags: u8,
 ) -> Result<()> {
     let debug = ExecuteFlags::from_bits(flags)
@@ -83,6 +86,7 @@ pub fn direct_execute<'a, 'b, 'c, 'info>(
     // We now need to verify that the signer (at the moment, only one is supported) is a valid signer for the cryptid account
     verify_keys(
         &ctx.accounts.did,
+        Some(did_account_bump),
         ctx.accounts.signer.to_account_info().key,
         controlling_did_accounts,
     )?;

--- a/programs/cryptid/src/instructions/execute_transaction.rs
+++ b/programs/cryptid/src/instructions/execute_transaction.rs
@@ -12,7 +12,9 @@ use anchor_lang::prelude::*;
 /// A vector of the number of extras for each signer, signer count is the length
 controller_chain: Vec<u8>,
 /// The bump seed for the Cryptid signer
-bump: u8,
+cryptid_account_bump: u8,
+/// The bump seed for the Did Account
+did_account_bump: u8,
 /// Additional flags
 flags: u8,
 )]
@@ -77,7 +79,8 @@ impl<'a, 'b, 'c, 'info> AllAccounts<'a, 'b, 'c, 'info>
 pub fn execute_transaction<'a, 'b, 'c, 'info>(
     ctx: Context<'a, 'b, 'c, 'info, ExecuteTransaction<'info>>,
     controller_chain: Vec<u8>,
-    bump: u8,
+    cryptid_account_bump: u8,
+    did_account_bump: u8,
     flags: u8,
 ) -> Result<()> {
     let debug = ExecuteFlags::from_bits(flags)
@@ -98,6 +101,7 @@ pub fn execute_transaction<'a, 'b, 'c, 'info>(
     // We now need to verify that the signer (at the moment, only one is supported) is a valid signer for the cryptid account
     verify_keys(
         &ctx.accounts.did,
+        Some(did_account_bump),
         ctx.accounts.signer.to_account_info().key,
         controlling_did_accounts,
     )?;
@@ -110,7 +114,7 @@ pub fn execute_transaction<'a, 'b, 'c, 'info>(
         &ctx.accounts.did.key(),
         &ctx.accounts.cryptid_account,
         &ctx.accounts.cryptid_account.to_account_info(),
-        bump,
+        cryptid_account_bump,
         debug,
     )?;
 

--- a/programs/cryptid/src/instructions/execute_transaction.rs
+++ b/programs/cryptid/src/instructions/execute_transaction.rs
@@ -23,7 +23,12 @@ flags: u8,
 pub struct ExecuteTransaction<'info> {
     /// The Cryptid instance to execute with
     /// CHECK: Cryptid Account can be generative and non-generative
-    #[account(mut)]
+    #[account(
+        mut,
+        // TODO: Verification dones in instruction body. Move back with Anchor generator
+        // seeds = [CryptidAccount::SEED_PREFIX, did_program.key().as_ref(), did.key().as_ref(), cryptid_account_index.to_le_bytes().as_ref()],
+        // bump = cryptid_account_bump
+    )]
     pub cryptid_account: UncheckedAccount<'info>,
     /// The DID on the Cryptid instance
     /// CHECK: DID Account can be generative or not

--- a/programs/cryptid/src/instructions/propose_transaction.rs
+++ b/programs/cryptid/src/instructions/propose_transaction.rs
@@ -12,13 +12,13 @@ num_accounts: u8
 )]
 pub struct ProposeTransaction<'info> {
     /// The Cryptid instance that can execute the transaction.
-    /// CHECK: This assumes a purely generative case until we have use-cases that require a state.
+    /// CHECK: Cryptid Account can be generative and non-generative
     #[account()]
-    pub cryptid_account: UncheckedAccount<'info>, // TODO allow generative/non-generative
-    /// The owner of the Cryptid instance, typically a DID account
+    pub cryptid_account: UncheckedAccount<'info>,
+    /// The did account owner of the Cryptid instance
     /// CHECK: Unchecked to allow generative DID accounts.
     #[account()]
-    pub owner: UncheckedAccount<'info>, // TODO allow generative/non-generative
+    pub did: UncheckedAccount<'info>,
     #[account(mut)]
     authority: Signer<'info>,
     #[account(
@@ -40,7 +40,7 @@ pub fn propose_transaction<'a, 'b, 'c, 'info>(
     ctx: Context<'a, 'b, 'c, 'info, ProposeTransaction<'info>>,
     instructions: Vec<AbbreviatedInstructionData>,
 ) -> Result<()> {
-    ctx.accounts.transaction_account.owner = *ctx.accounts.owner.key;
+    ctx.accounts.transaction_account.did = *ctx.accounts.did.key;
     ctx.accounts.transaction_account.instructions = instructions;
     ctx.accounts.transaction_account.cryptid_account = *ctx.accounts.cryptid_account.key;
     ctx.accounts.transaction_account.approved_middleware = None;

--- a/programs/cryptid/src/instructions/propose_transaction.rs
+++ b/programs/cryptid/src/instructions/propose_transaction.rs
@@ -1,14 +1,20 @@
+use crate::instructions::util::{resolve_by_index, verify_keys, AllAccounts};
 use crate::state::abbreviated_instruction_data::AbbreviatedInstructionData;
 use crate::state::instruction_size::InstructionSize;
 use crate::state::transaction_account::TransactionAccount;
 use crate::state::transaction_state::TransactionState;
+use crate::util::SolDID;
 use anchor_lang::prelude::*;
 
 #[derive(Accounts)]
 #[instruction(
+/// A vector of the number of extras for each signer, signer count is the length
+controller_chain: Vec<u8>,
+/// The bump seed for the Cryptid signer
+cryptid_account_bump: u8,
 /// The instructions to execute
 instructions: Vec<AbbreviatedInstructionData>,
-num_accounts: u8
+num_accounts: u8,
 )]
 pub struct ProposeTransaction<'info> {
     /// The Cryptid instance that can execute the transaction.
@@ -19,6 +25,8 @@ pub struct ProposeTransaction<'info> {
     /// CHECK: Unchecked to allow generative DID accounts.
     #[account()]
     pub did: UncheckedAccount<'info>,
+    /// The program for the DID
+    pub did_program: Program<'info, SolDID>,
     #[account(mut)]
     authority: Signer<'info>,
     #[account(
@@ -28,18 +36,60 @@ pub struct ProposeTransaction<'info> {
             num_accounts.into(),
             InstructionSize::from_iter_to_iter(
                 instructions.iter()
-            )
-        ))
+                )
+       ))
     ]
     transaction_account: Account<'info, TransactionAccount>,
     system_program: Program<'info, System>,
 }
+
+/// Collect all accounts as a single vector so that they can be referenced by index by instructions
+// TODO: Note - I initially wanted to use some crate to iterate over a struct's fields, so I could define
+// this for all Contexts automatically, but failed. We could either leave it like this or try again.
+// Once decided, remove this comment.
+impl<'a, 'b, 'c, 'info> AllAccounts<'a, 'b, 'c, 'info>
+    for Context<'a, 'b, 'c, 'info, ProposeTransaction<'info>>
+{
+    fn all_accounts(&self) -> Vec<&AccountInfo<'info>> {
+        [
+            self.accounts.cryptid_account.as_ref(),
+            self.accounts.did.as_ref(),
+            self.accounts.did_program.as_ref(),
+            self.accounts.authority.as_ref(),
+        ]
+        .into_iter()
+        .chain(self.remaining_accounts.iter())
+        .collect()
+    }
+
+    fn get_accounts_by_indexes(&self, indexes: &[u8]) -> Result<Vec<&AccountInfo<'info>>> {
+        let accounts = self.all_accounts();
+        resolve_by_index(indexes, &accounts)
+    }
+}
+
 /// Propose a transaction to be executed by a cryptid account
 /// Note - at present, there is no constraint on who can propose a transaction.
 pub fn propose_transaction<'a, 'b, 'c, 'info>(
     ctx: Context<'a, 'b, 'c, 'info, ProposeTransaction<'info>>,
+    controller_chain: Vec<u8>,
+    did_account_bump: u8,
     instructions: Vec<AbbreviatedInstructionData>,
 ) -> Result<()> {
+    // convert the controller chain (an array of account indices) into an array of accounts
+    // note - cryptid does not need to check that the chain is valid, or even that they are DIDs
+    // sol_did does that
+    let controlling_did_accounts = ctx.get_accounts_by_indexes(controller_chain.as_slice())?;
+
+    // Assume at this point that anchor has verified the cryptid account and did account (but not the controller chain)
+    // We now need to verify that the signer (at the moment, only one is supported) is a valid signer for the cryptid account
+    verify_keys(
+        &ctx.accounts.did,
+        Some(did_account_bump),
+        ctx.accounts.authority.to_account_info().key,
+        controlling_did_accounts,
+    )?;
+
     ctx.accounts.transaction_account.did = *ctx.accounts.did.key;
     ctx.accounts.transaction_account.instructions = instructions;
     ctx.accounts.transaction_account.cryptid_account = *ctx.accounts.cryptid_account.key;

--- a/programs/cryptid/src/instructions/util.rs
+++ b/programs/cryptid/src/instructions/util.rs
@@ -49,6 +49,7 @@ impl<T: AccountSerialize + AccountDeserialize + Owner + Clone> IsGenerative<T> f
 /// Otherwise, the signer is a signer on a controller of the DID (either directly or indirectly)
 pub fn verify_keys<'info1, 'info2>(
     did: &AccountInfo<'info1>,
+    did_account_bump: Option<u8>,
     signer: &Pubkey,
     controlling_did_accounts: Vec<&AccountInfo<'info2>>,
 ) -> Result<()> {
@@ -58,7 +59,7 @@ pub fn verify_keys<'info1, 'info2>(
         .collect::<Vec<_>>();
     let signer_is_authority = sol_did::integrations::is_authority(
         did,
-        None,
+        did_account_bump,
         controlling_did_accounts.as_slice(),
         signer,
         &[],

--- a/programs/cryptid/src/instructions/util.rs
+++ b/programs/cryptid/src/instructions/util.rs
@@ -68,7 +68,7 @@ pub fn verify_keys<'info1, 'info2>(
     )
     .map_err(|error| -> CryptidError {
         msg!("Error executing is_authority: {}", error);
-        CryptidError::KeyCannotChangeTransaction
+        CryptidError::KeyMustBeSigner
     })?;
 
     if !signer_is_authority {

--- a/programs/cryptid/src/lib.rs
+++ b/programs/cryptid/src/lib.rs
@@ -57,6 +57,7 @@ pub mod cryptid {
         ctx: Context<'a, 'b, 'c, 'info, ExecuteTransaction<'info>>,
         controller_chain: Vec<u8>,
         cryptid_account_bump: u8,
+        cryptid_account_index: u32,
         did_account_bump: u8,
         flags: u8,
     ) -> Result<()> {
@@ -64,6 +65,7 @@ pub mod cryptid {
             ctx,
             controller_chain,
             cryptid_account_bump,
+            cryptid_account_index,
             did_account_bump,
             flags,
         )

--- a/programs/cryptid/src/lib.rs
+++ b/programs/cryptid/src/lib.rs
@@ -20,9 +20,9 @@ pub mod cryptid {
         ctx: Context<Create>,
         middleware: Option<Pubkey>,
         index: u32,
-        bump: u8,
+        did_account_bump: u8,
     ) -> Result<()> {
-        instructions::create(ctx, middleware, index, bump)
+        instructions::create(ctx, middleware, index, did_account_bump)
     }
 
     pub fn direct_execute<'a, 'b, 'c, 'info>(
@@ -30,6 +30,7 @@ pub mod cryptid {
         controller_chain: Vec<u8>,
         instructions: Vec<AbbreviatedInstructionData>,
         cryptid_account_bump: u8,
+        did_account_bump: u8,
         flags: u8,
     ) -> Result<()> {
         instructions::direct_execute(
@@ -37,6 +38,7 @@ pub mod cryptid {
             controller_chain,
             instructions,
             cryptid_account_bump,
+            did_account_bump,
             flags,
         )
     }
@@ -53,9 +55,16 @@ pub mod cryptid {
         ctx: Context<'a, 'b, 'c, 'info, ExecuteTransaction<'info>>,
         controller_chain: Vec<u8>,
         cryptid_account_bump: u8,
+        did_account_bump: u8,
         flags: u8,
     ) -> Result<()> {
-        instructions::execute_transaction(ctx, controller_chain, cryptid_account_bump, flags)
+        instructions::execute_transaction(
+            ctx,
+            controller_chain,
+            cryptid_account_bump,
+            did_account_bump,
+            flags,
+        )
     }
 
     pub fn approve_execution<'a, 'b, 'c, 'info>(

--- a/programs/cryptid/src/lib.rs
+++ b/programs/cryptid/src/lib.rs
@@ -48,11 +48,20 @@ pub mod cryptid {
     pub fn propose_transaction<'a, 'b, 'c, 'info>(
         ctx: Context<'a, 'b, 'c, 'info, ProposeTransaction<'info>>,
         controller_chain: Vec<u8>,
+        cryptid_account_bump: u8,
+        cryptid_account_index: u32,
         did_account_bump: u8,
         instructions: Vec<AbbreviatedInstructionData>,
         _num_accounts: u8,
     ) -> Result<()> {
-        instructions::propose_transaction(ctx, controller_chain, did_account_bump, instructions)
+        instructions::propose_transaction(
+            ctx,
+            controller_chain,
+            cryptid_account_bump,
+            cryptid_account_index,
+            did_account_bump,
+            instructions,
+        )
     }
 
     pub fn execute_transaction<'a, 'b, 'c, 'info>(

--- a/programs/cryptid/src/lib.rs
+++ b/programs/cryptid/src/lib.rs
@@ -30,6 +30,7 @@ pub mod cryptid {
         controller_chain: Vec<u8>,
         instructions: Vec<AbbreviatedInstructionData>,
         cryptid_account_bump: u8,
+        cryptid_account_index: u32,
         did_account_bump: u8,
         flags: u8,
     ) -> Result<()> {
@@ -38,6 +39,7 @@ pub mod cryptid {
             controller_chain,
             instructions,
             cryptid_account_bump,
+            cryptid_account_index,
             did_account_bump,
             flags,
         )

--- a/programs/cryptid/src/lib.rs
+++ b/programs/cryptid/src/lib.rs
@@ -47,10 +47,12 @@ pub mod cryptid {
 
     pub fn propose_transaction<'a, 'b, 'c, 'info>(
         ctx: Context<'a, 'b, 'c, 'info, ProposeTransaction<'info>>,
+        controller_chain: Vec<u8>,
+        did_account_bump: u8,
         instructions: Vec<AbbreviatedInstructionData>,
         _num_accounts: u8,
     ) -> Result<()> {
-        instructions::propose_transaction(ctx, instructions)
+        instructions::propose_transaction(ctx, controller_chain, did_account_bump, instructions)
     }
 
     pub fn execute_transaction<'a, 'b, 'c, 'info>(

--- a/programs/cryptid/src/state/cryptid_account.rs
+++ b/programs/cryptid/src/state/cryptid_account.rs
@@ -1,3 +1,4 @@
+use crate::{error::CryptidError, id};
 use anchor_lang::prelude::*;
 
 /// The data for an on-chain Cryptid Account
@@ -13,4 +14,50 @@ impl CryptidAccount {
     pub const SEED_PREFIX: &'static [u8] = b"cryptid_account";
 
     pub const MAX_SIZE: usize = (1 + 32) + 4;
+
+    // Support generative and non-generative accounts
+    pub fn try_from(
+        cryptid_account: &AccountInfo,
+        did_program: &Pubkey,
+        did: &Pubkey,
+        index: u32,
+        cryptid_account_bump: u8,
+    ) -> Result<CryptidAccount> {
+        // Verify seed derivation
+        let derived_cryptid_account =
+            derive_cryptid_account_with_bump(did_program, did, index, cryptid_account_bump)?;
+        if derived_cryptid_account != *cryptid_account.key {
+            return Err(error!(CryptidError::WrongCryptidAccount));
+        }
+
+        if cryptid_account.owner == &System::id() {
+            return Ok(CryptidAccount {
+                middleware: None,
+                index,
+            });
+        }
+
+        // Non-generative account
+        let cryptid_account: Account<CryptidAccount> = Account::try_from(cryptid_account)?;
+        Ok(cryptid_account.into_inner())
+    }
+}
+
+pub fn derive_cryptid_account_with_bump(
+    did_program: &Pubkey,
+    did: &Pubkey,
+    index: u32,
+    bump_seed: u8,
+) -> Result<Pubkey> {
+    Pubkey::create_program_address(
+        &[
+            CryptidAccount::SEED_PREFIX,
+            did_program.key().as_ref(),
+            did.key().as_ref(),
+            index.to_le_bytes().as_ref(),
+            &[bump_seed],
+        ],
+        &id(),
+    )
+    .map_err(|_| Error::from(ErrorCode::ConstraintSeeds))
 }

--- a/programs/cryptid/src/state/transaction_account.rs
+++ b/programs/cryptid/src/state/transaction_account.rs
@@ -12,7 +12,7 @@ pub struct TransactionAccount {
     /// The cryptid account for the transaction
     pub cryptid_account: Pubkey,
     /// The owner of the cryptid account (Typically a DID account)
-    pub owner: Pubkey,
+    pub did: Pubkey,
     /// The accounts `instructions` references (excluding the cryptid account
     pub accounts: Vec<Pubkey>,
     /// The instructions that will be executed
@@ -35,7 +35,7 @@ impl TransactionAccount {
     ) -> usize {
         DISCRIMINATOR_SIZE
             + 32 // cryptid_account
-            + 32 // owner
+            + 32 // did (owner)
             + 4 + 32 * num_accounts //accounts
             + 4 + instruction_sizes.into_iter().map(AbbreviatedInstructionData::calculate_size).sum::<usize>() //transaction_instructions
             + 1 + 32 // approved_middleware
@@ -119,7 +119,7 @@ mod test {
 
         let account = TransactionAccount {
             cryptid_account: Default::default(),
-            owner: Default::default(),
+            did: Default::default(),
             accounts: vec![Default::default()],
             instructions: vec![AbbreviatedInstructionData {
                 program_id: 0,

--- a/programs/middleware/check_pass/src/lib.rs
+++ b/programs/middleware/check_pass/src/lib.rs
@@ -82,7 +82,7 @@ pub mod check_pass {
         // WARNING - any logic added after here is skipped if the transaction is signed
         // by the failsafe key.
 
-        let did = &ctx.accounts.owner;
+        let did = &ctx.accounts.did;
         // TODO - this should be in the gateway SDK.
         let gateway_token_info = &ctx.accounts.gateway_token.to_account_info();
         let gateway_token = Gateway::parse_gateway_token(gateway_token_info)
@@ -177,7 +177,7 @@ pub struct ExecuteMiddleware<'info> {
     pub middleware_account: Account<'info, CheckPass>,
     #[account(
         mut,
-        has_one = owner,
+        has_one = did,
     )]
     pub transaction_account: Account<'info, TransactionAccount>,
     /// The owner of the Cryptid instance, typically a DID account
@@ -185,7 +185,7 @@ pub struct ExecuteMiddleware<'info> {
     /// The gateway token can be on any key provably owned by the DID.
     /// CHECK: DID Account can be generative or not
     #[account()]
-    pub owner: UncheckedAccount<'info>,
+    pub did: UncheckedAccount<'info>,
     /// An authority on the DID.
     /// This is needed for two cases:
     /// 1) the expireOnUse case. In this case, the authority must be the owner of the gateway token.


### PR DESCRIPTION
- Integrated `did_account_bump` for all instructions that are passed a `did`
- Fixed wrong utilization of `bump` during anchor `init`
- Support generative and non-generative cryptidAccounts on all interfaces
- Implemented authority check on proposeTransaction
- Removed any transaction signing from the Service layer.
- Test Refactors and Cleanup