### PR TITLE
IDCOM-2206 Updated Cryptid build interface to match the create interface

### DIFF
--- a/packages/client/core/src/api/cryptidBuilder.ts
+++ b/packages/client/core/src/api/cryptidBuilder.ts
@@ -1,15 +1,9 @@
-import {
-  BuildOptions,
-  CryptidClient,
-  CryptidOptions,
-  FindAllOptions,
-} from "./cryptidClient";
+import { CryptidClient, CryptidOptions, FindAllOptions } from "./cryptidClient";
 import { Wallet } from "../types/crypto";
 import { Keypair } from "@solana/web3.js";
 import { SimpleCryptidClient } from "./simpleCryptidClient";
 import { normalizeSigner } from "../lib/crypto";
 import { CryptidAccountDetails } from "../lib/CryptidAccountDetails";
-import { Middleware } from "../lib/Middleware";
 import { CryptidService } from "../service/cryptid";
 import { didToPDA } from "../lib/did";
 import { getCryptidAccountAddress } from "../lib/cryptid";
@@ -23,10 +17,10 @@ export class CryptidBuilder {
     return new SimpleCryptidClient(details, normalizeSigner(signer), options);
   }
 
-  static buildFromDID(
+  static loadFromDID(
     did: string,
     signer: Keypair | Wallet,
-    options: BuildOptions
+    options: CryptidOptions
   ): CryptidClient {
     const details = CryptidAccountDetails.from(
       did,
@@ -54,7 +48,6 @@ export class CryptidBuilder {
   static createFromDID(
     did: string,
     signer: Keypair | Wallet,
-    middleware: Middleware[],
     options: CryptidOptions
   ): Promise<CryptidClient> {
     const index = options.accountIndex === undefined ? 1 : options.accountIndex; // 0 is reserved for the default (generative) cryptid
@@ -67,7 +60,7 @@ export class CryptidBuilder {
       did,
       didAccount[0],
       didAccount[1],
-      middleware
+      options.middlewares ?? []
     );
     return CryptidBuilder.create(details, signer, options);
   }

--- a/packages/client/core/src/api/cryptidClient.ts
+++ b/packages/client/core/src/api/cryptidClient.ts
@@ -22,12 +22,10 @@ export type CryptidOptions = {
   confirmOptions?: ConfirmOptions;
   waitForConfirmation?: boolean;
   rentPayer?: PayerOption;
+  middlewares?: Middleware[];
 };
 export type FindAllOptions = {
   connection: Connection;
-};
-export type BuildOptions = CryptidOptions & {
-  middlewares?: Middleware[];
 };
 
 export const DEFAULT_CRYPTID_OPTIONS: Partial<CryptidOptions> = {

--- a/packages/tests/src/directExecute.ts
+++ b/packages/tests/src/directExecute.ts
@@ -71,7 +71,7 @@ didTestCases.forEach(({ didType, getDidAccount }) => {
     });
 
     before("Set up generative Cryptid Account", async () => {
-      cryptid = await Cryptid.buildFromDID(did, authority, {
+      cryptid = await Cryptid.loadFromDID(did, authority, {
         connection: provider.connection,
       });
 
@@ -155,7 +155,7 @@ didTestCases.forEach(({ didType, getDidAccount }) => {
       // fund the bogus signer, otherwise the tx fails due to lack of funds, not did signing issues
       await fund(bogusSigner.publicKey);
 
-      const bogusCryptid = await Cryptid.buildFromDID(did, bogusSigner, {
+      const bogusCryptid = await Cryptid.loadFromDID(did, bogusSigner, {
         connection: provider.connection,
       });
       const signedTransaction = await bogusCryptid.directExecute(
@@ -171,7 +171,7 @@ didTestCases.forEach(({ didType, getDidAccount }) => {
     it("can use direct-execute on non-zero index cryptid accounts", async () => {
       const recipient = Keypair.generate();
 
-      const cryptidNonZeroIndex = await Cryptid.buildFromDID(did, authority, {
+      const cryptidNonZeroIndex = await Cryptid.loadFromDID(did, authority, {
         accountIndex: 1,
         connection: provider.connection,
       });
@@ -196,7 +196,7 @@ didTestCases.forEach(({ didType, getDidAccount }) => {
 
         const recipient = Keypair.generate();
 
-        const secondKeyCryptid = await Cryptid.buildFromDID(did, secondKey, {
+        const secondKeyCryptid = await Cryptid.loadFromDID(did, secondKey, {
           connection: provider.connection,
         });
 

--- a/packages/tests/src/middleware/checkPass.ts
+++ b/packages/tests/src/middleware/checkPass.ts
@@ -132,8 +132,11 @@ describe("Middleware: checkPass", () => {
     cryptid = await Cryptid.createFromDID(
       DID_SOL_PREFIX + ":" + authority.publicKey,
       signer,
-      middleware,
-      { connection: provider.connection, accountIndex: ++cryptidIndex }
+      {
+        connection: provider.connection,
+        accountIndex: ++cryptidIndex,
+        middlewares: middleware,
+      }
     );
 
     await fund(cryptid.address(), 20 * LAMPORTS_PER_SOL);

--- a/packages/tests/src/util/cryptid.ts
+++ b/packages/tests/src/util/cryptid.ts
@@ -184,7 +184,6 @@ export const createCryptid = async (
   Builder.createFromDID(
     DID_SOL_PREFIX + ":" + authority.publicKey,
     authority,
-    [],
     options
   );
 
@@ -192,7 +191,7 @@ export const buildCryptid = async (
   authority: Wallet,
   options: CryptidOptions
 ): Promise<CryptidClient> =>
-  await Builder.buildFromDID(
+  await Builder.loadFromDID(
     DID_SOL_PREFIX + ":" + authority.publicKey,
     authority,
     options
@@ -205,7 +204,7 @@ export const cryptidTestCases = [
       did: string,
       authority: Wallet | Keypair,
       options: CryptidOptions
-    ) => Builder.buildFromDID(did, authority, options),
+    ) => Builder.loadFromDID(did, authority, options),
   },
   {
     cryptidType: TestType.Initialized,
@@ -213,7 +212,7 @@ export const cryptidTestCases = [
       did: string,
       authority: Wallet | Keypair,
       options: CryptidOptions
-    ) => Builder.createFromDID(did, authority, [], options),
+    ) => Builder.createFromDID(did, authority, options),
   },
 ];
 


### PR DESCRIPTION
* Update `buildFromDID` to accept middleware as part of the options (consistent with `createFromDID`
* Rename `buildFromDID` to `loadFromDID`

Additional detail: https://civicteam.slack.com/archives/C03JUBN7WFL/p1668695749336159