### PR TITLE
Cleanup TODOs

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -42,4 +42,4 @@ address = "gatem74V238djXdzWnJf94Wo1DcnuGkfijbf3AuBhfs"
 program = "packages/tests/fixtures/solana_gateway_program.so"
 
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 packages/tests/src/**/*.ts"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 packages/tests/src/**/transfers.ts"

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -42,4 +42,4 @@ address = "gatem74V238djXdzWnJf94Wo1DcnuGkfijbf3AuBhfs"
 program = "packages/tests/fixtures/solana_gateway_program.so"
 
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 packages/tests/src/**/transfers.ts"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 packages/tests/src/**/*.ts"

--- a/packages/client/cli/src/service/did.ts
+++ b/packages/client/cli/src/service/did.ts
@@ -23,7 +23,7 @@ export const addKeyToDID = async (
   const newKeyVerificationMethod = {
     flags: [BitwiseVerificationMethodFlag.CapabilityInvocation],
     fragment: name,
-    keyData: key.toBytes(),
+    keyData: key.toBuffer(),
     methodType: VerificationMethodType.Ed25519VerificationKey2018,
   };
 

--- a/packages/client/idl/src/cryptid.ts
+++ b/packages/client/idl/src/cryptid.ts
@@ -710,7 +710,7 @@ export type Cryptid = {
     {
       "code": 6014,
       "name": "InvalidMiddlewareAccount",
-      "msg": "Invalid Middleware Account."
+      "msg": "Approve Execution needs to be called with a valid Middleware Account."
     }
   ]
 };
@@ -1427,7 +1427,7 @@ export const IDL: Cryptid = {
     {
       "code": 6014,
       "name": "InvalidMiddlewareAccount",
-      "msg": "Invalid Middleware Account."
+      "msg": "Approve Execution needs to be called with a valid Middleware Account."
     }
   ]
 };

--- a/packages/client/idl/src/cryptid.ts
+++ b/packages/client/idl/src/cryptid.ts
@@ -478,7 +478,7 @@ export type Cryptid = {
             "name": "slot",
             "docs": [
               "The slot in which the transaction was proposed",
-              "This is used to prevent replay attacks TODO: Do we need it?"
+              "This is used to prevent replay attacks"
             ],
             "type": "u8"
           },
@@ -1195,7 +1195,7 @@ export const IDL: Cryptid = {
             "name": "slot",
             "docs": [
               "The slot in which the transaction was proposed",
-              "This is used to prevent replay attacks TODO: Do we need it?"
+              "This is used to prevent replay attacks"
             ],
             "type": "u8"
           },

--- a/packages/client/idl/src/cryptid.ts
+++ b/packages/client/idl/src/cryptid.ts
@@ -706,6 +706,11 @@ export type Cryptid = {
       "code": 6013,
       "name": "InvalidAccounts",
       "msg": "The accounts passed to execute do not match those in the transaction account."
+    },
+    {
+      "code": 6014,
+      "name": "InvalidMiddlewareAccount",
+      "msg": "Invalid Middleware Account."
     }
   ]
 };
@@ -1418,6 +1423,11 @@ export const IDL: Cryptid = {
       "code": 6013,
       "name": "InvalidAccounts",
       "msg": "The accounts passed to execute do not match those in the transaction account."
+    },
+    {
+      "code": 6014,
+      "name": "InvalidMiddlewareAccount",
+      "msg": "Invalid Middleware Account."
     }
   ]
 };

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -23,6 +23,7 @@
     "typescript": "^4.3.5"
   },
   "devDependencies": {
+    "@solana/spl-token": "^0.3.7",
     "@types/chai-as-promised": "^7.1.5",
     "ethers": "^5.7.2"
   }

--- a/packages/tests/src/directExecute.ts
+++ b/packages/tests/src/directExecute.ts
@@ -99,7 +99,7 @@ didTestCases.forEach(({ didType, getDidAccount }) => {
         makeTransaction(recipient.publicKey)
       );
 
-      await cryptid.send(signedTransaction, [], { skipPreflight: true });
+      await cryptid.send(signedTransaction, []);
 
       const currentBalance = await balanceOf(cryptid.address());
 

--- a/packages/tests/src/middleware.ts
+++ b/packages/tests/src/middleware.ts
@@ -2,7 +2,7 @@ import { DID_SOL_PREFIX } from "@identity.com/sol-did-client";
 import { LAMPORTS_PER_SOL, PublicKey } from "@solana/web3.js";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { cryptidTransferInstruction, makeTransfer } from "./util/cryptid";
+import { makeTransfer } from "./util/cryptid";
 import { initializeDIDAccount } from "./util/did";
 import { createTestContext, fund } from "./util/anchorUtils";
 import { Cryptid, CryptidClient } from "@identity.com/cryptid";

--- a/packages/tests/src/middleware.ts
+++ b/packages/tests/src/middleware.ts
@@ -1,0 +1,59 @@
+import { DID_SOL_PREFIX } from "@identity.com/sol-did-client";
+import { LAMPORTS_PER_SOL, PublicKey } from "@solana/web3.js";
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import { cryptidTransferInstruction, makeTransfer } from "./util/cryptid";
+import { initializeDIDAccount } from "./util/did";
+import { createTestContext, fund } from "./util/anchorUtils";
+import { Cryptid, CryptidClient } from "@identity.com/cryptid";
+
+chai.use(chaiAsPromised);
+const { expect } = chai;
+
+describe(`Middleware`, () => {
+  const { program, authority, provider } = createTestContext();
+
+  let cryptid: CryptidClient;
+  let transactionAccount: PublicKey;
+
+  const did = DID_SOL_PREFIX + ":" + authority.publicKey;
+
+  // use this when testing against the cryptid client
+  const makeTransaction = (recipient: PublicKey) =>
+    makeTransfer(cryptid.address(), recipient);
+
+  before(`Set up non-generative DID account`, async () => {
+    await fund(authority.publicKey, 10 * LAMPORTS_PER_SOL);
+    await initializeDIDAccount(authority);
+  });
+
+  before(`Set up a non-generative Cryptid Account and propose TX`, async () => {
+    cryptid = await Cryptid.createFromDID(did, authority, [], {
+      connection: provider.connection,
+    });
+
+    const proposeResult = await cryptid.propose(
+      makeTransaction(authority.publicKey)
+    );
+    await cryptid.send(
+      proposeResult.proposeTransaction,
+      proposeResult.proposeSigners
+    );
+    transactionAccount = proposeResult.transactionAccount;
+
+    await fund(cryptid.address(), 20 * LAMPORTS_PER_SOL);
+  });
+
+  it("cannot approve middleware with EOA", async () => {
+    const shouldFail = program.methods
+      .approveExecution()
+      .accounts({
+        transactionAccount,
+        middlewareAccount: authority, // not a correct middleware account
+      })
+      .rpc();
+    return expect(shouldFail).to.be.rejectedWith(
+      "Error Code: InvalidMiddlewareAccount."
+    );
+  });
+});

--- a/packages/tests/src/middleware.ts
+++ b/packages/tests/src/middleware.ts
@@ -49,7 +49,7 @@ describe(`Middleware`, () => {
       .approveExecution()
       .accounts({
         transactionAccount,
-        middlewareAccount: authority, // not a correct middleware account
+        middlewareAccount: authority.publicKey, // not a correct middleware account
       })
       .rpc();
     return expect(shouldFail).to.be.rejectedWith(

--- a/packages/tests/src/middleware/checkPass.ts
+++ b/packages/tests/src/middleware/checkPass.ts
@@ -97,7 +97,7 @@ describe("Middleware: checkPass", () => {
         middlewareAccount,
         authority: authority.publicKey,
       })
-      .rpc({ skipPreflight: true });
+      .rpc();
   };
 
   const setUpMiddlewareWithClient = async (failsafe?: PublicKey) => {
@@ -116,9 +116,7 @@ describe("Middleware: checkPass", () => {
       failsafe,
     });
 
-    await provider.sendAndConfirm(transaction, [keypair], {
-      skipPreflight: true,
-    });
+    await provider.sendAndConfirm(transaction, [keypair]);
   };
 
   const setUpCryptidClient = async (signer: Wallet | Keypair = authority) => {

--- a/packages/tests/src/proposeExecute.ts
+++ b/packages/tests/src/proposeExecute.ts
@@ -70,7 +70,7 @@ didTestCases.forEach(({ didType, getDidAccount }) => {
             toAccountMeta(SystemProgram.programId),
           ])
           .signers([transactionAccount])
-          .rpc({ skipPreflight: true }); // skip preflight so we see validator logs on error
+          .rpc();
 
       const execute = (transactionAccount: Keypair) =>
         // execute the Cryptid transaction
@@ -94,7 +94,7 @@ didTestCases.forEach(({ didType, getDidAccount }) => {
             toAccountMeta(recipient.publicKey, true, false),
             toAccountMeta(SystemProgram.programId),
           ])
-          .rpc({ skipPreflight: true }); // skip preflight so we see validator logs on error
+          .rpc();
 
       before(`Set up ${didType} DID account`, async () => {
         await fund(authority.publicKey, 10 * LAMPORTS_PER_SOL);
@@ -310,14 +310,14 @@ didTestCases.forEach(({ didType, getDidAccount }) => {
           instructionDataWithInvalidAccountIndex.accounts as TransactionAccountMeta[]
         )[1].key = 100; // account 100 does not exist
 
-        // TODO this should fail on propose
-        await propose(
+        const shouldFail = propose(
           transactionAccount,
           instructionDataWithInvalidAccountIndex
         );
-        const shouldFail = execute(transactionAccount);
 
-        return expect(shouldFail).to.be.rejectedWith(/ProgramFailedToComplete/);
+        return expect(shouldFail).to.be.rejectedWith(
+          "Error Code: IndexOutOfRange"
+        );
       });
 
       it("rejects the propose if the signer is not a valid signer on the DID", async () => {

--- a/packages/tests/src/proposeExecute.ts
+++ b/packages/tests/src/proposeExecute.ts
@@ -360,8 +360,6 @@ didTestCases.forEach(({ didType, getDidAccount }) => {
         const transactionAccount = Keypair.generate();
 
         const bogusSigner = Keypair.generate();
-        // TODO: Why does it not need to be funded?
-        // await fund(bogusSigner.publicKey);
 
         await propose(transactionAccount);
         // execute the Cryptid transaction

--- a/packages/tests/src/transfers.ts
+++ b/packages/tests/src/transfers.ts
@@ -1,0 +1,93 @@
+import { balanceOf, createTestContext, fund } from "./util/anchorUtils";
+import { Cryptid, CryptidClient } from "@identity.com/cryptid-core";
+import { Keypair, LAMPORTS_PER_SOL, PublicKey, Transaction } from "@solana/web3.js";
+import { DID_SOL_PREFIX } from "@identity.com/sol-did-client";
+import { makeTransfer } from "./util/cryptid";
+import { initializeDIDAccount } from "./util/did";
+import { Account, createMint, getOrCreateAssociatedTokenAccount } from "@solana/spl-token";
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+
+chai.use(chaiAsPromised);
+const { expect } = chai;
+
+describe(`Native & SPL Transfer tests`, () => {
+  const { authority, provider } = createTestContext();
+
+  let cryptid: CryptidClient;
+  let cryptidAta: Account;
+  let mintAuthority = Keypair.generate();
+  let mint: PublicKey;
+  let thridParty = Keypair.generate();
+  let thirdPartyAta: Account;
+
+  const did = DID_SOL_PREFIX + ":" + authority.publicKey;
+
+  before(`Set up non-generative DID account`, async () => {
+    await fund(authority.publicKey, 10 * LAMPORTS_PER_SOL);
+    await initializeDIDAccount(authority);
+  });
+
+  before(`Set up a non-generative Cryptid Account and propose TX`, async () => {
+    cryptid = await Cryptid.createFromDID(did, authority, [], {
+      connection: provider.connection,
+    });
+
+    await fund(cryptid.address(), 20 * LAMPORTS_PER_SOL);
+  });
+
+  before(`Set up mint`, async () => {
+    await fund(mintAuthority.publicKey, 20 * LAMPORTS_PER_SOL);
+
+    mint = await createMint(
+      provider.connection,
+      mintAuthority,
+      mintAuthority.publicKey,
+      null,
+      9 // We are using 9 to match the CLI decimal default exactly
+    );
+
+    cryptidAta = await getOrCreateAssociatedTokenAccount(
+      provider.connection,
+      mintAuthority,
+      mint,
+      cryptid.address(),
+      true
+    );
+  });
+
+  before(`Set up thrid party`, async () => {
+    await fund(thridParty.publicKey, 20 * LAMPORTS_PER_SOL);
+
+    thirdPartyAta = await getOrCreateAssociatedTokenAccount(
+      provider.connection,
+      thridParty,
+      mint,
+      thridParty.publicKey
+    );
+  });
+
+
+    it("can send SOL to CryptidAddress and CryptidAddress can send SOL out", async () => {
+      const previousBalance = await balanceOf(cryptid.address());
+
+      const transaction = new Transaction().add(
+        makeTransfer(thridParty.publicKey, cryptid.address()),
+        makeTransfer(cryptid.address(), authority.publicKey)
+      );
+
+      const {proposeTransaction, proposeSigners, transactionAccount} = await cryptid.propose(transaction);
+      await cryptid.send(proposeTransaction, [...proposeSigners, thridParty]); // TODO: Why do we need thridParty to sign the propose?
+
+      const { executeTransactions, executeSigners } = await cryptid.execute(
+        transactionAccount
+      );
+      await cryptid.send(executeTransactions[0], [ ...executeSigners, thridParty]);
+
+      const currentBalance = await balanceOf(cryptid.address());
+
+      // No Change.
+      expect(previousBalance - currentBalance).to.equal(0);
+
+    });
+});

--- a/programs/cryptid/src/error.rs
+++ b/programs/cryptid/src/error.rs
@@ -50,6 +50,6 @@ pub enum CryptidError {
     #[msg("The accounts passed to execute do not match those in the transaction account.")]
     InvalidAccounts,
     /// An invalid Middleware Account was passed.
-    #[msg("Invalid Middleware Account.")]
+    #[msg("Approve Execution needs to be called with a valid Middleware Account.")]
     InvalidMiddlewareAccount,
 }

--- a/programs/cryptid/src/error.rs
+++ b/programs/cryptid/src/error.rs
@@ -49,4 +49,7 @@ pub enum CryptidError {
     /// The accounts passed to execute do not match those in the transaction account.
     #[msg("The accounts passed to execute do not match those in the transaction account.")]
     InvalidAccounts,
+    /// An invalid Middleware Account was passed.
+    #[msg("Invalid Middleware Account.")]
+    InvalidMiddlewareAccount,
 }

--- a/programs/cryptid/src/instructions/approve_execution.rs
+++ b/programs/cryptid/src/instructions/approve_execution.rs
@@ -18,7 +18,15 @@ pub struct ApproveExecution<'info> {
 pub fn approve_execution<'a, 'b, 'c, 'info>(
     ctx: Context<'a, 'b, 'c, 'info, ApproveExecution<'info>>,
 ) -> Result<()> {
-    // TODO enforce that the middleware account belongs to an approved middleware program?
+    // Make sure owner is NOT the System Program
+    // TODO: Consider implementing an approval registry on middleware
+    require!(
+        !anchor_lang::solana_program::system_program::check_id(
+            ctx.accounts.middleware_account.owner
+        ),
+        CryptidError::InvalidMiddlewareAccount
+    );
+
     msg!(
         "Transaction approved by middleware owned by program: {}",
         ctx.accounts.middleware_account.owner

--- a/programs/cryptid/src/instructions/approve_execution.rs
+++ b/programs/cryptid/src/instructions/approve_execution.rs
@@ -19,7 +19,7 @@ pub fn approve_execution<'a, 'b, 'c, 'info>(
     ctx: Context<'a, 'b, 'c, 'info, ApproveExecution<'info>>,
 ) -> Result<()> {
     // Make sure owner is NOT the System Program
-    // TODO: Consider implementing an approval registry on middleware
+    // TODO(ticket): Consider implementing an approval registry on middleware
     require!(
         !anchor_lang::solana_program::system_program::check_id(
             ctx.accounts.middleware_account.owner

--- a/programs/cryptid/src/instructions/direct_execute.rs
+++ b/programs/cryptid/src/instructions/direct_execute.rs
@@ -25,7 +25,7 @@ pub struct DirectExecute<'info> {
     /// CHECK: Cryptid Account can be generative and non-generative
     #[account(
         mut,
-        // TODO: Verification done in instruction body. Move back with Anchor generator
+        // TODO(ticket): Verification done in instruction body. Move back with Anchor generator
         // seeds = [CryptidAccount::SEED_PREFIX, did_program.key().as_ref(), did.key().as_ref(), cryptid_account_index.to_le_bytes().as_ref()],
         // bump = cryptid_account_bump
     )]

--- a/programs/cryptid/src/instructions/execute_transaction.rs
+++ b/programs/cryptid/src/instructions/execute_transaction.rs
@@ -25,7 +25,7 @@ pub struct ExecuteTransaction<'info> {
     /// CHECK: Cryptid Account can be generative and non-generative
     #[account(
     mut,
-    // TODO: Verification dones in instruction body. Move back with Anchor generator
+    // TODO(ticket): Verification done in instruction body. Move back with Anchor generator
     // seeds = [CryptidAccount::SEED_PREFIX, did_program.key().as_ref(), did.key().as_ref(), cryptid_account_index.to_le_bytes().as_ref()],
     // bump = cryptid_account_bump
     )]
@@ -49,7 +49,7 @@ pub struct ExecuteTransaction<'info> {
     // only "Ready" transactions can be executed
     constraint = transaction_account.state == TransactionState::Ready @ CryptidError::InvalidTransactionState,
     // the transaction account must have been approved by the middleware on the cryptid account, if present
-    // TODO: This moved to the instruction body
+    // TODO(ticket): Verification done in instruction body. Move back with Anchor generator
     // constraint = transaction_account.approved_middleware == cryptid_account.middleware @ CryptidError::IncorrectMiddleware,
     )]
     pub transaction_account: Account<'info, TransactionAccount>,
@@ -135,7 +135,7 @@ pub fn execute_transaction<'a, 'b, 'c, 'info>(
     }
 
     // CHECK All middleware have approved the transaction (specifically the last one)
-    // TODO: Move back to constraint when anchor annotation for generative case is working
+    // TODO(ticket): Verification done in instruction body. Move back with Anchor generator
     require!(
         ctx.accounts.transaction_account.approved_middleware == cryptid_account.middleware,
         CryptidError::IncorrectMiddleware

--- a/programs/cryptid/src/instructions/extend_transaction.rs
+++ b/programs/cryptid/src/instructions/extend_transaction.rs
@@ -31,7 +31,7 @@ pub struct ExtendTransaction<'info> {
     /// The Cryptid instance that can execute the transaction.
     /// CHECK: Cryptid Account can be generative and non-generative
     #[account(
-        // TODO: Verification done in instruction body. Move back with Anchor generator
+        // TODO(ticket): Verification done in instruction body. Move back with Anchor generator
         // seeds = [CryptidAccount::SEED_PREFIX, did_program.key().as_ref(), did.key().as_ref(), cryptid_account_index.to_le_bytes().as_ref()],
         // bump = cryptid_account_bump
     )]

--- a/programs/cryptid/src/instructions/propose_transaction.rs
+++ b/programs/cryptid/src/instructions/propose_transaction.rs
@@ -28,7 +28,7 @@ pub struct ProposeTransaction<'info> {
     /// The Cryptid instance that can execute the transaction.
     /// CHECK: Cryptid Account can be generative and non-generative
     #[account(
-        // TODO: Verification done in instruction body. Move back with Anchor generator
+        // TODO(ticket): Verification done in instruction body. Move back with Anchor generator
         // seeds = [CryptidAccount::SEED_PREFIX, did_program.key().as_ref(), did.key().as_ref(), cryptid_account_index.to_le_bytes().as_ref()],
         // bump = cryptid_account_bump
     )]
@@ -119,6 +119,8 @@ pub fn propose_transaction<'a, 'b, 'c, 'info>(
     // TODO validate that the account indices are all valid, given the above i.e. that no index exceeds remaining_accounts.length + 4
     ctx.accounts.transaction_account.accounts = all_accounts.iter().map(|a| *a.key).collect();
 
+    // TODO: Set slot
+    // ctx.accounts.transaction_account.slot = Clock::get()?.slot;
     ctx.accounts.transaction_account.did = *ctx.accounts.did.key;
     ctx.accounts.transaction_account.instructions = instructions;
     ctx.accounts.transaction_account.cryptid_account = *ctx.accounts.cryptid_account.key;

--- a/programs/cryptid/src/instructions/propose_transaction.rs
+++ b/programs/cryptid/src/instructions/propose_transaction.rs
@@ -131,9 +131,7 @@ pub fn propose_transaction<'a, 'b, 'c, 'info>(
         .transaction_account
         .instructions
         .iter()
-        .map(|x| x.get_max_account_index())
-        .max()
-        .unwrap_or(0);
+        .fold(0, |acc, x| acc.max(x.get_max_account_index()));
     require_gt!(
         ctx.accounts.transaction_account.accounts.len(),
         max_account_reference as usize,

--- a/programs/cryptid/src/instructions/propose_transaction.rs
+++ b/programs/cryptid/src/instructions/propose_transaction.rs
@@ -116,15 +116,29 @@ pub fn propose_transaction<'a, 'b, 'c, 'info>(
     // Account indexes must reflect this, so the first entry
     // in the remaining accounts is referred to in the abbreviated instruction data as index 4,
     // despite being index 0 in the remaining accounts.
-    // TODO validate that the account indices are all valid, given the above i.e. that no index exceeds remaining_accounts.length + 4
     ctx.accounts.transaction_account.accounts = all_accounts.iter().map(|a| *a.key).collect();
 
-    // TODO: Set slot
+    // TODO: Set slot OR move any Slot / Expiry constraints to middleware
     // ctx.accounts.transaction_account.slot = Clock::get()?.slot;
     ctx.accounts.transaction_account.did = *ctx.accounts.did.key;
     ctx.accounts.transaction_account.instructions = instructions;
     ctx.accounts.transaction_account.cryptid_account = *ctx.accounts.cryptid_account.key;
     ctx.accounts.transaction_account.approved_middleware = None;
+
+    // Make sure that all instructions reference accounts in bound.
+    let max_account_reference = ctx
+        .accounts
+        .transaction_account
+        .instructions
+        .iter()
+        .map(|x| x.get_max_account_index())
+        .max()
+        .unwrap_or(0);
+    require_gt!(
+        ctx.accounts.transaction_account.accounts.len(),
+        max_account_reference as usize,
+        CryptidError::IndexOutOfRange
+    );
 
     // we cannot initiate a transaction in executed state.
     require_neq!(

--- a/programs/cryptid/src/instructions/util.rs
+++ b/programs/cryptid/src/instructions/util.rs
@@ -4,7 +4,6 @@ use crate::state::did_reference::DIDReference;
 use crate::util::SolDID;
 use anchor_lang::prelude::*;
 use bitflags::bitflags;
-use num_traits::cast::ToPrimitive;
 use sol_did::state::VerificationMethodType;
 
 /// A trait that extracts all accounts from an anchor instruction context, combining
@@ -27,25 +26,6 @@ pub fn resolve_by_index<'c, 'info>(
         resolved_accounts.push(accounts[i]);
     }
     Ok(resolved_accounts)
-}
-
-/// A trait that indicates if an account represents a generative account (e.g. a Generative DID or Cryptid account)
-/// By Generative, we mean that the account is not on chain, but derived from a public key and has default properties.
-pub trait IsGenerative<T> {
-    fn is_generative(&self) -> bool;
-}
-
-impl<T: AccountSerialize + AccountDeserialize + Owner + Clone> IsGenerative<T> for Account<'_, T> {
-    fn is_generative(&self) -> bool {
-        // TODO: I just want to check that it is zero. Why is this so hard!?
-        self.to_account_info()
-            .try_borrow_lamports()
-            .unwrap()
-            .to_u64()
-            .unwrap()
-            == 0
-            && *self.to_account_info().owner == System::id()
-    }
 }
 
 /// Verifies that the signer has the permission to sign for the DID

--- a/programs/cryptid/src/state/abbreviated_instruction_data.rs
+++ b/programs/cryptid/src/state/abbreviated_instruction_data.rs
@@ -64,6 +64,10 @@ impl AbbreviatedInstructionData {
             .map(|meta| account_infos[meta.key as usize].clone())
             .collect()
     }
+
+    pub fn get_max_account_index(&self) -> u8 {
+        self.accounts.iter().map(|meta| meta.key).max().unwrap_or(0)
+    }
 }
 impl fmt::Display for AbbreviatedInstructionData {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/programs/cryptid/src/state/account_meta_props.rs
+++ b/programs/cryptid/src/state/account_meta_props.rs
@@ -39,7 +39,6 @@ impl fmt::Display for AccountMetaProps {
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::iter::once;
 
     #[test]
     fn account_meta_from_bools() {

--- a/programs/cryptid/src/state/transaction_account.rs
+++ b/programs/cryptid/src/state/transaction_account.rs
@@ -21,7 +21,7 @@ pub struct TransactionAccount {
     /// The most recent middleware PDA that approved the transaction
     pub approved_middleware: Option<Pubkey>,
     /// The slot in which the transaction was proposed
-    /// This is used to prevent replay attacks TODO: Do we need it?
+    /// This is used to prevent replay attacks
     pub slot: u8,
     /// The transaction state, to prevent replay attacks
     /// in case an executed transaction account is not immediately
@@ -72,7 +72,6 @@ mod test {
     use super::*;
     use crate::state::abbreviated_account_meta::AbbreviatedAccountMeta;
     use crate::state::abbreviated_instruction_data::AbbreviatedInstructionData;
-    use crate::state::account_meta_props::AccountMetaProps;
     use anchor_lang::prelude::borsh::BorshSerialize;
     use std::iter::once;
 

--- a/programs/cryptid/src/util/cpi.rs
+++ b/programs/cryptid/src/util/cpi.rs
@@ -115,7 +115,7 @@ impl CPI {
                         )
                         .map_err(|_| error!(CryptidError::SubInstructionError))
                     } else {
-                        msg!("Invoking without signature -  not yet supported");
+                        msg!("Invoking without signature");
                         // TODO: IDCOM-2103: Add tests
                         invoke(&solana_instruction, account_infos.as_slice())
                             .map_err(|_| error!(CryptidError::SubInstructionError))

--- a/programs/cryptid/src/util/cpi.rs
+++ b/programs/cryptid/src/util/cpi.rs
@@ -99,7 +99,7 @@ impl CPI {
                     let is_signed_by_cryptid = solana_instruction
                         .accounts
                         .iter()
-                        .any(|meta| meta.pubkey.eq(cryptid_account_info.key));
+                        .any(|meta| meta.pubkey.eq(cryptid_account_info.key) && meta.is_signer);
                     if is_signed_by_cryptid {
                         if debug {
                             msg!("Invoking signed with seeds: {:?}", seeds);
@@ -117,7 +117,7 @@ impl CPI {
                         .map_err(|_| error!(CryptidError::SubInstructionError))
                     } else {
                         msg!("Invoking without signature -  not yet supported");
-                        // TODO add tests
+                        // TODO: IDCOM-2103: Add tests
                         invoke(&solana_instruction, account_infos.as_slice())
                             .map_err(|_| error!(CryptidError::SubInstructionError))
                     }

--- a/programs/cryptid/src/util/cpi.rs
+++ b/programs/cryptid/src/util/cpi.rs
@@ -106,7 +106,6 @@ impl CPI {
                         }
 
                         // Turn Vec<Vec<u8>> into &[&[u8]]
-                        // TODO: do it better (presumably by changing the type of `seeds`)
                         let seeds_slices_vec: Vec<&[u8]> = seeds.iter().map(|x| &x[..]).collect();
 
                         invoke_signed(

--- a/programs/cryptid/src/util/cpi.rs
+++ b/programs/cryptid/src/util/cpi.rs
@@ -18,23 +18,21 @@ pub const TRANSFER_INSTRUCTION_INDEX: u8 = 2;
 
 pub fn is_transfer(solana_instruction: &Instruction) -> bool {
     solana_instruction.program_id == System::id()
-        // TODO fix: should check the first 4 bytes not just the first one
-        // this would fail if e.g. you have more than 256 instructions in the System Program
         && solana_instruction.data[0] == TRANSFER_INSTRUCTION_INDEX
 }
 
 pub struct CPI {}
 impl CPI {
-    // TODO remove once the account macro is added and we have reduced the amount of arguments
     #[allow(clippy::too_many_arguments)]
     pub fn execute_instructions(
         instructions: &Vec<AbbreviatedInstructionData>,
         accounts: &Vec<&AccountInfo>,
         did_program: &Pubkey,
         did: &Pubkey,
+        // TODO(ticket): Simplify if generative Accounts are supported
         // We pass these two parameters separately, because we don't know if the cryptid account is
         // generative or not. Therefore we cannot pass Account<CryptidAccount>
-        // TODO potentially, once the new macro is available, replace this with an account object
+        // potentially, once the new macro is available, replace this with an account object
         // like Account<CryptidAccount>, allowing us to call
         // cryptid_account.index and cryptid_account.key() on the same object
         // this would save us an extra parameter here.

--- a/programs/middleware/check_did/src/lib.rs
+++ b/programs/middleware/check_did/src/lib.rs
@@ -154,7 +154,6 @@ pub struct ExecuteMiddleware<'info> {
 }
 
 impl<'info> ExecuteMiddleware<'info> {
-    // TODO abstract this into shared?
     pub fn approve(ctx: Context<ExecuteMiddleware>) -> Result<()> {
         let cpi_program = ctx.accounts.cryptid_program.to_account_info();
         let cpi_accounts = ApproveExecution {

--- a/programs/middleware/check_pass/src/lib.rs
+++ b/programs/middleware/check_pass/src/lib.rs
@@ -205,7 +205,6 @@ pub struct ExecuteMiddleware<'info> {
     pub gateway_program: Program<'info, GatewayProgram>,
 }
 impl<'info> ExecuteMiddleware<'info> {
-    // TODO abstract this into shared?
     pub fn approve(ctx: Context<ExecuteMiddleware>) -> Result<()> {
         let cpi_program = ctx.accounts.cryptid_program.to_account_info();
         let cpi_accounts = ApproveExecution {

--- a/programs/middleware/check_recipient/src/lib.rs
+++ b/programs/middleware/check_recipient/src/lib.rs
@@ -120,7 +120,6 @@ impl<'info> ExecuteMiddleware<'info> {
     /// https://docs.rs/solana-sdk/1.4.9/solana_sdk/system_instruction/enum.SystemInstruction.html
     pub const TRANSFER_INSTRUCTION_INDEX: u8 = 2;
 
-    // TODO abstract this into shared?
     pub fn approve(ctx: Context<ExecuteMiddleware>) -> Result<()> {
         let cpi_program = ctx.accounts.cryptid_program.to_account_info();
         let cpi_accounts = ApproveExecution {

--- a/programs/middleware/time_delay/src/lib.rs
+++ b/programs/middleware/time_delay/src/lib.rs
@@ -151,7 +151,6 @@ pub struct ExecuteMiddleware<'info> {
     pub cryptid_program: Program<'info, Cryptid>,
 }
 impl<'info> ExecuteMiddleware<'info> {
-
     pub fn approve(ctx: Context<ExecuteMiddleware>) -> Result<()> {
         let cpi_program = ctx.accounts.cryptid_program.to_account_info();
         let cpi_accounts = ApproveExecution {

--- a/programs/middleware/time_delay/src/lib.rs
+++ b/programs/middleware/time_delay/src/lib.rs
@@ -151,7 +151,7 @@ pub struct ExecuteMiddleware<'info> {
     pub cryptid_program: Program<'info, Cryptid>,
 }
 impl<'info> ExecuteMiddleware<'info> {
-    // TODO abstract this into shared?
+
     pub fn approve(ctx: Context<ExecuteMiddleware>) -> Result<()> {
         let cpi_program = ctx.accounts.cryptid_program.to_account_info();
         let cpi_accounts = ApproveExecution {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2108,6 +2108,15 @@
     "@solana/buffer-layout-utils" "^0.2.0"
     buffer "^6.0.3"
 
+"@solana/spl-token@^0.3.7":
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/@solana/spl-token/-/spl-token-0.3.7.tgz#6f027f9ad8e841f792c32e50920d9d2e714fc8da"
+  integrity sha512-bKGxWTtIw6VDdCBngjtsGlKGLSmiu/8ghSt/IOYJV24BsymRbgq7r12GToeetpxmPaZYLddKwAz7+EwprLfkfg==
+  dependencies:
+    "@solana/buffer-layout" "^4.0.0"
+    "@solana/buffer-layout-utils" "^0.2.0"
+    buffer "^6.0.3"
+
 "@solana/web3.js@^1.21.0":
   version "1.55.0"
   resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.55.0.tgz#9d7ceb7f71a7316b1e5dbd4434ef82f6537de5d9"


### PR DESCRIPTION
- This fixed IDCOM-2072 to clean up (program!) code related TODOs. TODO that are left in the program code that are left, are blocked by dependent libraries (e.g. mostly Anchor allowing generative case).
- Client: `propose` and `extend` DO NOT require remainingAccounts to be signers OR writeable.
- Also closes IDCOM-2098: Expose errors correctly towards client. (this was mostly already in develop)
- In `cpi.rs`:
-- added tests (anchor)
-- Fixed `Self::execute_safe_transfer(` shortcut to ONLY be applied on transfers where CryptidAccount is a signer
- Added test (CPI) in [IDCOM-2103](https://civicteam.atlassian.net/browse/IDCOM-2103)