### PR TITLE
Feature/idcom 2261  superuser middleware

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -4,7 +4,8 @@ members = [
     "programs/middleware/check_recipient",
     "programs/middleware/check_pass",
     "programs/middleware/check_did",
-    "programs/middleware/time_delay"
+    "programs/middleware/time_delay",
+    "programs/middleware/superuser_check_signer"
 ]
 types = "packages/client/idl/src"
 
@@ -18,6 +19,7 @@ check_recipient = "midcHDoZsxvMmNtUr8howe8MWFrJeHHPbAyJF1nHvyf"
 check_pass = "midpT1DeQGnKUjmGbEtUMyugXL5oEBeXU3myBMntkKo"
 check_did = "midb3GKX7wF1minPXeDKqGRKCK9NeR8ns9V8BQUMJDr"
 time_delay = "midttN2h6G2CBvt1kpnwUsFXM6Gv7gratVwuo2XhSNk"
+superuser_check_signer = "midsEy2qfSX1gguxZT3Kv4dGTDisi7iDMAJfSmyG5Y9"
 
 [programs.mainnet]
 cryptid = "cryptJTh61jY5kbUmBEXyc86tBUyueBDrLuNSZWmUcs"
@@ -25,6 +27,7 @@ check_recipient = "midcHDoZsxvMmNtUr8howe8MWFrJeHHPbAyJF1nHvyf"
 check_pass = "midpT1DeQGnKUjmGbEtUMyugXL5oEBeXU3myBMntkKo"
 check_did = "midb3GKX7wF1minPXeDKqGRKCK9NeR8ns9V8BQUMJDr"
 time_delay = "midttN2h6G2CBvt1kpnwUsFXM6Gv7gratVwuo2XhSNk"
+superuser_check_signer = "midsEy2qfSX1gguxZT3Kv4dGTDisi7iDMAJfSmyG5Y9"
 
 [registry]
 url = "https://api.apr.dev"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,6 +1376,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
+name = "superuser_check_signer"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "cryptid",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/README.md
+++ b/README.md
@@ -231,3 +231,43 @@ The initial instructions in a transaction are serialised and added as data to th
 serialization adds some overhead to the transaction size, meaning that some transactions that initially fit within the
 transaction size limit may now exceed it. On the roadmap are plans to allow transactions to be chunked to avoid this
 limitation.
+
+## Middleware
+
+Out-of-the-box Cryptid provides multi-key access to assets, based on a DID.
+
+The true power of Cryptid comes from the ability to extend its functionality with middleware.
+
+Middlewares are programs that intercept transactions before they are executed,
+and either allow or reject the transaction, based on their internal logic.
+
+They can be used to add security gates to transactions, to prevent fraud or error,
+or, in the case of "Superuser" middleware (see below), to allow a key to sign transactions
+that is not on the DID.
+
+Example middlewares, included in the Cryptid repo itself are:
+- CheckLimit: Rejects the transaction if the value exceeds a set limit.
+- CheckRecipient: Rejects a transaction if the recipient is not the expected one.
+- CheckPass: Requires a valid [pass](https://github.com/identity-com/on-chain-identity-gateway) to be associated with the sender wallet.
+- TimeDelay: Allows a transaction after a set delay.
+
+## Chaining Middleware
+
+Middleware can be composed together to create complex security policies.
+
+For example, by chaining the CheckLimit and CheckRecipient middleware, a transaction
+can be limited to a certain amount, and only allowed to be sent to a specific recipient.
+
+This allows use-cases such as "paying a bill", where a user can only send a certain amount
+to a specific recipient. Since a user may have a number of cryptid accounts, they may choose to set one
+up with these two middlewares, and use it to pay bills to a particular recipient.
+
+By chaining more complex middlewares with branching and "Superuser" middlewares, a complex set of
+constraints can be established in one single cryptid account.
+
+## Superuser Middleware
+
+The Superuser middleware allows a key to sign transactions that is not on the DID.
+It does this by bypassing the authority check in the core cryptid program. 
+This is naturally a highly risky operation, so superuser middlewares have to be listed explicitly
+in the Cryptid account, and cannot be changed after creation of the account.

--- a/README.md
+++ b/README.md
@@ -271,3 +271,6 @@ The Superuser middleware allows a key to sign transactions that is not on the DI
 It does this by bypassing the authority check in the core cryptid program. 
 This is naturally a highly risky operation, so superuser middlewares have to be listed explicitly
 in the Cryptid account, and cannot be changed after creation of the account.
+
+An example superuser middleware in this repo is superuser-check-signer, which verifies that a particular key
+has signed the transaction. This key need not be on the DID.

--- a/etc/publish-all.sh
+++ b/etc/publish-all.sh
@@ -30,12 +30,19 @@ echo Publishing cryptid-middleware-check-recipient@$1
   && yarn publish --tag alpha --new-version $1 --no-git-tag-version \
 )
 
+echo Publishing cryptid-middleware-superuser-check-signer@$1
+(cd packages/client/middleware/superuserCheckSigner \
+  && yarn add @identity.com/cryptid-core@$1 \
+  && yarn publish --tag alpha --new-version $1 --no-git-tag-version \
+)
+
 echo Publishing cryptid@$1
 (cd packages/client/cryptid \
   && yarn add @identity.com/cryptid-core@$1 \
     @identity.com/cryptid-middleware-check-pass@$1 \
     @identity.com/cryptid-middleware-time-delay@$1 \
     @identity.com/cryptid-middleware-check-recipient@$1 \
+    @identity.com/cryptid-middleware-superuser-check-signer@$1 \
   && yarn publish --tag alpha --new-version $1 --no-git-tag-version \
 )
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "packages/client/middleware/checkDid",
         "packages/client/middleware/timeDelay",
         "packages/client/middleware/checkRecipient",
+        "packages/client/middleware/superuserCheckSigner",
         "packages/client/core",
         "packages/client/cryptid",
         "packages/client/cli",

--- a/packages/client/cli/src/service/did.ts
+++ b/packages/client/cli/src/service/did.ts
@@ -23,7 +23,7 @@ export const addKeyToDID = async (
   const newKeyVerificationMethod = {
     flags: [BitwiseVerificationMethodFlag.CapabilityInvocation],
     fragment: name,
-    keyData: key.toBytes(),
+    keyData: key.toBuffer(),
     methodType: VerificationMethodType.Ed25519VerificationKey2018,
   };
 

--- a/packages/client/core/src/api/abstractCryptidClient.ts
+++ b/packages/client/core/src/api/abstractCryptidClient.ts
@@ -40,6 +40,7 @@ export abstract class AbstractCryptidClient implements CryptidClient {
   }
 
   abstract controlWith(controllerDid: string): CryptidClient;
+  abstract unauthorized(): CryptidClient;
 
   document(): Promise<DIDDocument> {
     return this.didClient().then((client) => client.resolve());
@@ -111,10 +112,11 @@ export abstract class AbstractCryptidClient implements CryptidClient {
 
   async propose(
     transaction: Transaction,
-    state?: TransactionState
+    state?: TransactionState,
+    allowUnauthorized = false
   ): Promise<ProposalResult> {
     return this.service().then((service) =>
-      service.propose(this.details, transaction, state)
+      service.propose(this.details, transaction, state, allowUnauthorized)
     );
   }
 

--- a/packages/client/core/src/api/controlledCryptidClient.ts
+++ b/packages/client/core/src/api/controlledCryptidClient.ts
@@ -1,6 +1,7 @@
 import { CryptidClient } from "./cryptidClient";
 import { AbstractCryptidClient } from "./abstractCryptidClient";
 import { Wallet } from "../types/crypto";
+import { UnauthorizedCryptidClient } from "./unauthorizedCryptidClient";
 
 export class ControlledCryptidClient extends AbstractCryptidClient {
   /**
@@ -23,6 +24,14 @@ export class ControlledCryptidClient extends AbstractCryptidClient {
 
   controlWith(controllerDid: string): CryptidClient {
     return new ControlledCryptidClient(controllerDid, this);
+  }
+
+  unauthorized(): CryptidClient {
+    return new UnauthorizedCryptidClient(
+      this.details,
+      this.wallet,
+      this.options
+    );
   }
 
   makeControllerChain(): string[] {

--- a/packages/client/core/src/api/cryptidClient.ts
+++ b/packages/client/core/src/api/cryptidClient.ts
@@ -23,6 +23,10 @@ export type CryptidOptions = {
   confirmOptions?: ConfirmOptions;
   waitForConfirmation?: boolean;
   rentPayer?: PayerOption;
+  // If the authority is a signer on the DID, authorized should be true.
+  // If this is an unauthorized client, authorized should be false.
+  // Should be set by the builder and not directly manipulated by the user.
+  authorized?: boolean;
 };
 export type CreateOptions = CryptidOptions & {
   // The chain of controllers, from the top (inclusive), to the one that owns the cryptid account (exclusive)
@@ -40,6 +44,7 @@ export type BuildOptions = CryptidOptions & {
 export const DEFAULT_CRYPTID_OPTIONS: Partial<CryptidOptions> = {
   accountIndex: 0,
   rentPayer: "DID_PAYS",
+  authorized: true,
 };
 
 /**
@@ -105,10 +110,13 @@ export interface CryptidClient {
    * Propose a transaction for execution by cryptid.
    * @param transaction The transaction to propose
    * @param state [TransactionState.Ready] The state to propose the transaction in. If NotReady, the transaction can be extended.
+   * @param allowUnauthorized If true, allows the transaction to be proposed even if the client authority is not a signer on the DID.
+   * It can then only be executed if a superuser middleware approves it.
    */
   propose(
     transaction: Transaction,
-    state?: TransactionState
+    state?: TransactionState,
+    allowUnauthorized?: boolean
   ): Promise<ProposalResult>;
 
   /**
@@ -159,6 +167,8 @@ export interface CryptidClient {
    * @param did The DID of the account to sign on behalf of.
    */
   controlWith(did: string): CryptidClient;
+
+  unauthorized(): CryptidClient;
 
   makeControllerChain(): string[];
 

--- a/packages/client/core/src/api/simpleCryptidClient.ts
+++ b/packages/client/core/src/api/simpleCryptidClient.ts
@@ -3,6 +3,7 @@ import { ControlledCryptidClient } from "./controlledCryptidClient";
 import { AbstractCryptidClient } from "./abstractCryptidClient";
 import { Wallet } from "../types/crypto";
 import { CryptidAccountDetails } from "../lib/CryptidAccountDetails";
+import { UnauthorizedCryptidClient } from "./unauthorizedCryptidClient";
 
 export class SimpleCryptidClient extends AbstractCryptidClient {
   constructor(
@@ -19,5 +20,13 @@ export class SimpleCryptidClient extends AbstractCryptidClient {
 
   controlWith(controllerDid: string): CryptidClient {
     return new ControlledCryptidClient(controllerDid, this);
+  }
+
+  unauthorized(): CryptidClient {
+    return new UnauthorizedCryptidClient(
+      this.details,
+      this.wallet,
+      this.options
+    );
   }
 }

--- a/packages/client/core/src/api/unauthorizedCryptidClient.ts
+++ b/packages/client/core/src/api/unauthorizedCryptidClient.ts
@@ -1,0 +1,64 @@
+import { CryptidClient, CryptidOptions } from "./cryptidClient";
+import { Wallet } from "../types/crypto";
+import { CryptidAccountDetails } from "../lib/CryptidAccountDetails";
+import { PublicKey, Transaction } from "@solana/web3.js";
+import { ProposalResult, TransactionState } from "../types/cryptid";
+import { AbstractCryptidClient } from "./abstractCryptidClient";
+import { ControlledCryptidClient } from "./controlledCryptidClient";
+
+export class UnauthorizedCryptidClient extends AbstractCryptidClient {
+  /**
+   * Create an unauthorized cryptid client.
+   *
+   * An unauthorized cryptid client is one where the authority is not a signer on the DID
+   * Unauthorized cryptid clients can only create unauthorized proposals.
+   * Unauthorized proposals can only be executed once approved by superuser middleware.
+   */
+  constructor(
+    details: CryptidAccountDetails,
+    private _wallet: Wallet,
+    options: CryptidOptions
+  ) {
+    super(details, {
+      ...options,
+      authorized: false,
+    });
+  }
+
+  get wallet(): Wallet {
+    return this._wallet;
+  }
+
+  controlWith(controllerDid: string): CryptidClient {
+    return new ControlledCryptidClient(controllerDid, this);
+  }
+
+  async propose(
+    transaction: Transaction,
+    state?: TransactionState
+  ): Promise<ProposalResult> {
+    return this.service().then((service) =>
+      service.propose(this.details, transaction, state, true)
+    );
+  }
+
+  async extend(
+    transactionAccountAddress: PublicKey,
+    transaction: Transaction,
+    state?: TransactionState
+  ): Promise<Transaction> {
+    return this.service().then((service) =>
+      service.extend(
+        this.details,
+        transactionAccountAddress,
+        transaction,
+        state,
+        true
+      )
+    );
+  }
+
+  unauthorized(): CryptidClient {
+    return this;
+  }
+}

--- a/packages/client/core/src/lib/CryptidTransaction.ts
+++ b/packages/client/core/src/lib/CryptidTransaction.ts
@@ -29,9 +29,9 @@ import {
 // Used to replace the current signer
 // so that the InstructionData are required to reference the signer in a separate position in the array,
 // and not index 3. This is because the signer is not known at creation time.
-// TODO - PublicKey.default uses the default key 11111111111111111111111111111111 which is the same as the system program.
+// PublicKey.default uses the default key 11111111111111111111111111111111 which is the same as the system program.
 // This is unsuitable as it may be referenced in the instructions somewhere. So we generate a "single use" key here.
-// It feels hacky - is there a better alternative?
+// TODO - It feels hacky - is there a better alternative?
 const NULL_KEY = Keypair.generate().publicKey; // PublicKey.default;
 
 export class CryptidTransaction {
@@ -142,7 +142,12 @@ export class CryptidTransaction {
       cryptidAccount.address,
       cryptidAccount.didAccount,
       DID_SOL_PROGRAM,
-      authority,
+      // This key is added in place of the signer (aka authority),
+      // so that the InstructionData are required to reference the signer in a separate position in the array,
+      // and not index 3. This is because the signer at execute time is not known at creation time,
+      // and may be different to the authority here.
+      // TODO: This is not the case for DirectExecute, so we could optimise here.
+      NULL_KEY,
     ];
     const allAccounts = transactionAccount.accounts;
     const accountMetasFromInstructions = transactionAccountMetasToAccountMetas(

--- a/packages/client/core/src/lib/CryptidTransaction.ts
+++ b/packages/client/core/src/lib/CryptidTransaction.ts
@@ -111,15 +111,15 @@ export class CryptidTransaction {
       ...controllersAccountMetas,
     ];
 
-    console.log("fromSolanaInstructions", {
-      authority: authority.toBase58(),
-      accountMetas: accountMetas.map((a) => a.pubkey.toBase58()),
-      filteredRemainingAccountMetas: filteredRemainingAccountMetas.map((a) =>
-        a.pubkey.toBase58()
-      ),
-      instructions: instructions.map((i) => i.accounts.map((a) => a.key)),
-      namedAccounts: namedAccounts.map((a) => a.toBase58()),
-    });
+    // console.log("fromSolanaInstructions", {
+    //   authority: authority.toBase58(),
+    //   accountMetas: accountMetas.map((a) => a.pubkey.toBase58()),
+    //   filteredRemainingAccountMetas: filteredRemainingAccountMetas.map((a) =>
+    //     a.pubkey.toBase58()
+    //   ),
+    //   instructions: instructions.map((i) => i.accounts.map((a) => a.key)),
+    //   namedAccounts: namedAccounts.map((a) => a.toBase58()),
+    // });
 
     return new CryptidTransaction(
       cryptidAccount,

--- a/packages/client/core/src/lib/Middleware.ts
+++ b/packages/client/core/src/lib/Middleware.ts
@@ -1,5 +1,9 @@
 import { PublicKey } from "@solana/web3.js";
 
 export class Middleware {
-  constructor(readonly programId: PublicKey, readonly address: PublicKey) {}
+  constructor(
+    readonly programId: PublicKey,
+    readonly address: PublicKey,
+    readonly isSuperuser = false
+  ) {}
 }

--- a/packages/client/core/src/service/cryptid.ts
+++ b/packages/client/core/src/service/cryptid.ts
@@ -151,10 +151,14 @@ export class CryptidService {
       details.middlewares.length > 0
         ? details.middlewares[details.middlewares.length - 1]
         : undefined;
+    const superuserMiddlewares = details.middlewares
+      .filter((m) => m.isSuperuser)
+      .map((m) => m.address);
     return (
       this.program.methods
         .createCryptidAccount(
           lastMiddleware?.address || null,
+          superuserMiddlewares,
           // Pass in the controller dids (if any)
           this.controllerChainPubkeys.map((c) => c[1]),
           details.index,

--- a/packages/client/core/src/service/cryptid.ts
+++ b/packages/client/core/src/service/cryptid.ts
@@ -274,6 +274,7 @@ export class CryptidService {
     // otherwise, wait until it is sealed
     let middlewareResult: MiddlewareResult = { instructions: [], signers: [] };
     if (state === TransactionState.Ready) {
+      console.log(`Executing MiddlewareInstructions`);
       middlewareResult = await this.executeMiddlewareInstructions(
         account,
         transactionAccountKeypair.publicKey,

--- a/packages/client/cryptid/README.md
+++ b/packages/client/cryptid/README.md
@@ -103,7 +103,7 @@ Each middleware requires the injection of a client SDK which creates the
 middleware instructions.
 
 The cryptid client supports the registration of custom middleware through
-a global signleton MiddlewareRegistry.
+a global singleton MiddlewareRegistry.
 
 To register a middleware client:
 

--- a/packages/client/cryptid/package.json
+++ b/packages/client/cryptid/package.json
@@ -17,7 +17,8 @@
     "@identity.com/cryptid-middleware-check-did": "0.3.0-alpha.11",
     "@identity.com/cryptid-middleware-check-pass": "0.3.0-alpha.11",
     "@identity.com/cryptid-middleware-check-recipient": "0.3.0-alpha.11",
-    "@identity.com/cryptid-middleware-time-delay": "0.3.0-alpha.11"
+    "@identity.com/cryptid-middleware-time-delay": "0.3.0-alpha.11",
+    "@identity.com/cryptid-middleware-superuser-check-signer": "0.3.0-alpha.11"
   },
   "devDependencies": {
     "rimraf": "^3.0.2"

--- a/packages/client/cryptid/src/index.ts
+++ b/packages/client/cryptid/src/index.ts
@@ -21,6 +21,11 @@ export {
   CheckRecipientMiddleware,
   CheckRecipientParameters,
 } from "@identity.com/cryptid-middleware-check-recipient";
+export {
+  SUPERUSER_CHECK_SIGNER_MIDDLEWARE_PROGRAM_ID,
+  SuperuserCheckSignerMiddleware,
+  SuperuserCheckSignerParameters,
+} from "@identity.com/cryptid-middleware-superuser-check-signer";
 
 import {
   CheckPassMiddleware,
@@ -42,6 +47,11 @@ import {
   CHECK_RECIPIENT_MIDDLEWARE_PROGRAM_ID,
 } from "@identity.com/cryptid-middleware-check-recipient";
 
+import {
+  SuperuserCheckSignerMiddleware,
+  SUPERUSER_CHECK_SIGNER_MIDDLEWARE_PROGRAM_ID,
+} from "@identity.com/cryptid-middleware-superuser-check-signer";
+
 MiddlewareRegistry.get().register(
   CHECK_PASS_MIDDLEWARE_PROGRAM_ID,
   new CheckPassMiddleware()
@@ -60,4 +70,9 @@ MiddlewareRegistry.get().register(
 MiddlewareRegistry.get().register(
   CHECK_RECIPIENT_MIDDLEWARE_PROGRAM_ID,
   new CheckRecipientMiddleware()
+);
+
+MiddlewareRegistry.get().register(
+    SUPERUSER_CHECK_SIGNER_MIDDLEWARE_PROGRAM_ID,
+    new SuperuserCheckSignerMiddleware()
 );

--- a/packages/client/cryptid/tsconfig.json
+++ b/packages/client/cryptid/tsconfig.json
@@ -23,6 +23,9 @@
     },
     {
       "path": "../middleware/checkRecipient"
+    },
+    {
+      "path": "../middleware/superuserCheckSigner"
     }
   ]
 }

--- a/packages/client/idl/src/cryptid.ts
+++ b/packages/client/idl/src/cryptid.ts
@@ -211,6 +211,10 @@ export type Cryptid = {
           }
         },
         {
+          "name": "allowUnauthorized",
+          "type": "bool"
+        },
+        {
           "name": "instructions",
           "type": {
             "vec": {
@@ -293,6 +297,10 @@ export type Cryptid = {
           "type": {
             "defined": "TransactionState"
           }
+        },
+        {
+          "name": "allowUnauthorized",
+          "type": "bool"
         },
         {
           "name": "instructions",
@@ -395,6 +403,27 @@ export type Cryptid = {
         {
           "name": "transactionAccount",
           "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "superuserApproveExecution",
+      "accounts": [
+        {
+          "name": "middlewareAccount",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "transactionAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "cryptidAccount",
+          "isMut": false,
           "isSigner": false
         }
       ],
@@ -507,6 +536,22 @@ export type Cryptid = {
             "type": {
               "defined": "TransactionState"
             }
+          },
+          {
+            "name": "unauthorizedSigner",
+            "docs": [
+              "If the transaction account is proposed by an authority on the DID, (the standard case)",
+              "then this is set to None.",
+              "If the transaction account is proposed by an unauthorized cryptid client, then",
+              "it is set to to that signer, and only a `superUser` middleware can approve it."
+            ],
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "authorized",
+            "type": "bool"
           }
         ]
       }
@@ -684,41 +729,51 @@ export type Cryptid = {
     },
     {
       "code": 6006,
+      "name": "UnauthorizedTransaction",
+      "msg": "The transaction was proposed by a non-authority on the DID and has not been authorized by a superuser middleware."
+    },
+    {
+      "code": 6007,
       "name": "AccountMismatch",
       "msg": "An account in the transaction accounts did not match what was expected"
     },
     {
-      "code": 6007,
+      "code": 6008,
       "name": "KeyMustBeSigner",
       "msg": "Signer is not authorised to sign for this Cryptid account"
     },
     {
-      "code": 6008,
+      "code": 6009,
       "name": "CreatingWithZeroIndex",
       "msg": "Attempt to create a Cryptid account with index zero, reserved for the default account."
     },
     {
-      "code": 6009,
+      "code": 6010,
       "name": "IndexOutOfRange",
       "msg": "Index out of range."
     },
     {
-      "code": 6010,
+      "code": 6011,
       "name": "NoAccountFromSeeds",
       "msg": "No account from seeds."
     },
     {
-      "code": 6011,
+      "code": 6012,
       "name": "AccountNotFromSeeds",
       "msg": "Account not from seeds."
     },
     {
-      "code": 6012,
+      "code": 6013,
       "name": "IncorrectMiddleware",
       "msg": "The expected middleware did not approve the transaction."
     },
     {
-      "code": 6013,
+      "code": 6014,
+      "name": "IncorrectSuperuserMiddleware",
+      "msg": "The middleware is not registered as a superuser middleware on the cryptid account."
+    },
+    {
+      "code": 6015,
       "name": "InvalidAccounts",
       "msg": "The accounts passed to execute do not match those in the transaction account."
     }
@@ -938,6 +993,10 @@ export const IDL: Cryptid = {
           }
         },
         {
+          "name": "allowUnauthorized",
+          "type": "bool"
+        },
+        {
           "name": "instructions",
           "type": {
             "vec": {
@@ -1020,6 +1079,10 @@ export const IDL: Cryptid = {
           "type": {
             "defined": "TransactionState"
           }
+        },
+        {
+          "name": "allowUnauthorized",
+          "type": "bool"
         },
         {
           "name": "instructions",
@@ -1122,6 +1185,27 @@ export const IDL: Cryptid = {
         {
           "name": "transactionAccount",
           "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "superuserApproveExecution",
+      "accounts": [
+        {
+          "name": "middlewareAccount",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "transactionAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "cryptidAccount",
+          "isMut": false,
           "isSigner": false
         }
       ],
@@ -1234,6 +1318,22 @@ export const IDL: Cryptid = {
             "type": {
               "defined": "TransactionState"
             }
+          },
+          {
+            "name": "unauthorizedSigner",
+            "docs": [
+              "If the transaction account is proposed by an authority on the DID, (the standard case)",
+              "then this is set to None.",
+              "If the transaction account is proposed by an unauthorized cryptid client, then",
+              "it is set to to that signer, and only a `superUser` middleware can approve it."
+            ],
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "authorized",
+            "type": "bool"
           }
         ]
       }
@@ -1411,41 +1511,51 @@ export const IDL: Cryptid = {
     },
     {
       "code": 6006,
+      "name": "UnauthorizedTransaction",
+      "msg": "The transaction was proposed by a non-authority on the DID and has not been authorized by a superuser middleware."
+    },
+    {
+      "code": 6007,
       "name": "AccountMismatch",
       "msg": "An account in the transaction accounts did not match what was expected"
     },
     {
-      "code": 6007,
+      "code": 6008,
       "name": "KeyMustBeSigner",
       "msg": "Signer is not authorised to sign for this Cryptid account"
     },
     {
-      "code": 6008,
+      "code": 6009,
       "name": "CreatingWithZeroIndex",
       "msg": "Attempt to create a Cryptid account with index zero, reserved for the default account."
     },
     {
-      "code": 6009,
+      "code": 6010,
       "name": "IndexOutOfRange",
       "msg": "Index out of range."
     },
     {
-      "code": 6010,
+      "code": 6011,
       "name": "NoAccountFromSeeds",
       "msg": "No account from seeds."
     },
     {
-      "code": 6011,
+      "code": 6012,
       "name": "AccountNotFromSeeds",
       "msg": "Account not from seeds."
     },
     {
-      "code": 6012,
+      "code": 6013,
       "name": "IncorrectMiddleware",
       "msg": "The expected middleware did not approve the transaction."
     },
     {
-      "code": 6013,
+      "code": 6014,
+      "name": "IncorrectSuperuserMiddleware",
+      "msg": "The middleware is not registered as a superuser middleware on the cryptid account."
+    },
+    {
+      "code": 6015,
       "name": "InvalidAccounts",
       "msg": "The accounts passed to execute do not match those in the transaction account."
     }

--- a/packages/client/idl/src/cryptid.ts
+++ b/packages/client/idl/src/cryptid.ts
@@ -48,6 +48,12 @@ export type Cryptid = {
           }
         },
         {
+          "name": "superuserMiddlewares",
+          "type": {
+            "vec": "publicKey"
+          }
+        },
+        {
           "name": "controllerChain",
           "type": {
             "vec": "publicKey"
@@ -419,6 +425,15 @@ export type Cryptid = {
               "The index of this cryptid account - allows multiple cryptid accounts per DID"
             ],
             "type": "u32"
+          },
+          {
+            "name": "superuserMiddleware",
+            "docs": [
+              "Middlewares that have \"Superuser\" status on the cryptid account"
+            ],
+            "type": {
+              "vec": "publicKey"
+            }
           }
         ]
       }
@@ -760,6 +775,12 @@ export const IDL: Cryptid = {
           }
         },
         {
+          "name": "superuserMiddlewares",
+          "type": {
+            "vec": "publicKey"
+          }
+        },
+        {
           "name": "controllerChain",
           "type": {
             "vec": "publicKey"
@@ -1131,6 +1152,15 @@ export const IDL: Cryptid = {
               "The index of this cryptid account - allows multiple cryptid accounts per DID"
             ],
             "type": "u32"
+          },
+          {
+            "name": "superuserMiddleware",
+            "docs": [
+              "Middlewares that have \"Superuser\" status on the cryptid account"
+            ],
+            "type": {
+              "vec": "publicKey"
+            }
           }
         ]
       }

--- a/packages/client/idl/src/index.ts
+++ b/packages/client/idl/src/index.ts
@@ -4,3 +4,4 @@ export { CheckPass, IDL as CheckPassIDL } from "./check_pass";
 export { CheckDid, IDL as CheckDidIDL } from "./check_did";
 export { CheckRecipient, IDL as CheckRecipientIDL } from "./check_recipient";
 export { TimeDelay, IDL as TimeDelayIDL } from "./time_delay";
+export { SuperuserCheckSigner, IDL as SuperuserCheckSignerIDL } from "./superuser_check_signer";

--- a/packages/client/idl/src/superuser_check_signer.ts
+++ b/packages/client/idl/src/superuser_check_signer.ts
@@ -1,0 +1,233 @@
+export type SuperuserCheckSigner = {
+  "version": "0.1.0",
+  "name": "superuser_check_signer",
+  "instructions": [
+    {
+      "name": "create",
+      "accounts": [
+        {
+          "name": "middlewareAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "signer",
+          "type": "publicKey"
+        },
+        {
+          "name": "bump",
+          "type": "u8"
+        },
+        {
+          "name": "previousMiddleware",
+          "type": {
+            "option": "publicKey"
+          }
+        }
+      ]
+    },
+    {
+      "name": "executeMiddleware",
+      "docs": [
+        "execute the middleware - checking that any previous middleware have been executed",
+        "Note- there is no additional check needed here - the signer check is already verified",
+        "by anchor."
+      ],
+      "accounts": [
+        {
+          "name": "middlewareAccount",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "transactionAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "cryptidAccount",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "signer",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "cryptidProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    }
+  ],
+  "accounts": [
+    {
+      "name": "superuserCheckSigner",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "signer",
+            "type": "publicKey"
+          },
+          {
+            "name": "authority",
+            "type": "publicKey"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "previousMiddleware",
+            "docs": [
+              "The previous middleware in the chain, if any"
+            ],
+            "type": {
+              "option": "publicKey"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "InvalidSigner",
+      "msg": "The middleware execution was signed by the wrong signer"
+    }
+  ]
+};
+
+export const IDL: SuperuserCheckSigner = {
+  "version": "0.1.0",
+  "name": "superuser_check_signer",
+  "instructions": [
+    {
+      "name": "create",
+      "accounts": [
+        {
+          "name": "middlewareAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "signer",
+          "type": "publicKey"
+        },
+        {
+          "name": "bump",
+          "type": "u8"
+        },
+        {
+          "name": "previousMiddleware",
+          "type": {
+            "option": "publicKey"
+          }
+        }
+      ]
+    },
+    {
+      "name": "executeMiddleware",
+      "docs": [
+        "execute the middleware - checking that any previous middleware have been executed",
+        "Note- there is no additional check needed here - the signer check is already verified",
+        "by anchor."
+      ],
+      "accounts": [
+        {
+          "name": "middlewareAccount",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "transactionAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "cryptidAccount",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "signer",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "cryptidProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    }
+  ],
+  "accounts": [
+    {
+      "name": "superuserCheckSigner",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "signer",
+            "type": "publicKey"
+          },
+          {
+            "name": "authority",
+            "type": "publicKey"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "previousMiddleware",
+            "docs": [
+              "The previous middleware in the chain, if any"
+            ],
+            "type": {
+              "option": "publicKey"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "InvalidSigner",
+      "msg": "The middleware execution was signed by the wrong signer"
+    }
+  ]
+};

--- a/packages/client/middleware/superuserCheckSigner/package.json
+++ b/packages/client/middleware/superuserCheckSigner/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@identity.com/cryptid-middleware-superuser-check-signer",
+  "version": "0.3.0-alpha.11",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rimraf dist",
+    "prebuild": "yarn clean",
+    "build": "tsc --build",
+    "lint": "eslint src/**/*.ts"
+  },
+  "dependencies": {
+    "@identity.com/cryptid-core": "0.3.0-alpha.11",
+    "@solana/web3.js": "^1.62.0",
+    "bn.js": "^5.2.1"
+  }
+}

--- a/packages/client/middleware/superuserCheckSigner/src/index.ts
+++ b/packages/client/middleware/superuserCheckSigner/src/index.ts
@@ -1,0 +1,124 @@
+import {
+  CRYPTID_PROGRAM,
+  ExecuteMiddlewareParams,
+  GenericMiddlewareParams,
+  MiddlewareClient,
+  MiddlewareResult,
+} from "@identity.com/cryptid-core";
+import {
+  PublicKey,
+  Transaction,
+  TransactionInstruction,
+} from "@solana/web3.js";
+import { AnchorProvider, Program } from "@project-serum/anchor";
+import {
+  SuperuserCheckSigner,
+  SuperuserCheckSignerIDL,
+} from "@identity.com/cryptid-idl";
+import * as anchor from "@project-serum/anchor";
+
+export const SUPERUSER_CHECK_SIGNER_MIDDLEWARE_PROGRAM_ID = new PublicKey(
+  "midsEy2qfSX1gguxZT3Kv4dGTDisi7iDMAJfSmyG5Y9"
+);
+
+export const deriveMiddlewareAccountAddress = (
+  authority: PublicKey,
+  signer: PublicKey,
+  previousMiddlewareAccount?: PublicKey
+): [PublicKey, number] =>
+  PublicKey.findProgramAddressSync(
+    [
+      anchor.utils.bytes.utf8.encode("superuser_check_signer"),
+      authority.toBuffer(),
+      signer.toBuffer(),
+      previousMiddlewareAccount?.toBuffer() || Buffer.alloc(32),
+    ],
+    SUPERUSER_CHECK_SIGNER_MIDDLEWARE_PROGRAM_ID
+  );
+
+export type SuperuserCheckSignerParameters = {
+  signer: PublicKey;
+} & GenericMiddlewareParams;
+export class SuperuserCheckSignerMiddleware
+  implements MiddlewareClient<SuperuserCheckSignerParameters>
+{
+  private static getProgram(
+    params: GenericMiddlewareParams
+  ): Program<SuperuserCheckSigner> {
+    // TODO probably move some of this to a common middleware utils lib
+    const anchorProvider = new AnchorProvider(
+      params.connection,
+      params.authority,
+      params.opts
+    );
+
+    return new Program<SuperuserCheckSigner>(
+      SuperuserCheckSignerIDL,
+      SUPERUSER_CHECK_SIGNER_MIDDLEWARE_PROGRAM_ID,
+      anchorProvider
+    );
+  }
+
+  public async createMiddleware(
+    params: SuperuserCheckSignerParameters
+  ): Promise<Transaction> {
+    const program = SuperuserCheckSignerMiddleware.getProgram(params);
+
+    const [middlewareAccount, middlewareBump] = deriveMiddlewareAccountAddress(
+      params.authority.publicKey,
+      params.signer,
+      params.previousMiddleware
+    );
+
+    return program.methods
+      .create(params.signer, middlewareBump, params.previousMiddleware || null)
+      .accounts({
+        middlewareAccount,
+        authority: params.authority.publicKey,
+      })
+      .transaction();
+  }
+
+  private async createExecuteInstruction(
+    program: Program<SuperuserCheckSigner>,
+    params: ExecuteMiddlewareParams
+  ): Promise<TransactionInstruction> {
+    return program.methods
+      .executeMiddleware()
+      .accounts({
+        middlewareAccount: params.middlewareAccount,
+        transactionAccount: params.transactionAccount,
+        cryptidAccount: params.cryptidAccountDetails.address,
+        cryptidProgram: CRYPTID_PROGRAM,
+      })
+      .instruction();
+  }
+
+  private async middlewareHasPreviousMiddleware(
+    program: Program<SuperuserCheckSigner>,
+    middlewareAccountAddress: PublicKey
+  ): Promise<boolean> {
+    const middlewareAccount = await program.account.superuserCheckSigner.fetch(
+      middlewareAccountAddress
+    );
+    return middlewareAccount.previousMiddleware !== null;
+  }
+
+  // Nothing to do on propose - only on execute
+  public async onPropose(): Promise<MiddlewareResult> {
+    return { instructions: [], signers: [] };
+  }
+
+  public async onExecute(
+    params: ExecuteMiddlewareParams
+  ): Promise<MiddlewareResult> {
+    const program = SuperuserCheckSignerMiddleware.getProgram(params);
+
+    const executeInstruction = await this.createExecuteInstruction(
+      program,
+      params
+    );
+
+    return { instructions: [executeInstruction], signers: [] };
+  }
+}

--- a/packages/client/middleware/superuserCheckSigner/tsconfig.json
+++ b/packages/client/middleware/superuserCheckSigner/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true
+  },
+  "include": [
+    "src/*",
+  ]
+}

--- a/packages/tests/src/middleware/chaining.ts
+++ b/packages/tests/src/middleware/chaining.ts
@@ -93,10 +93,12 @@ describe("Middleware chaining", () => {
       {
         programId: checkPassMiddlewareProgram.programId,
         address: checkPassMiddlewareAccount,
+        isSuperuser: false,
       },
       {
         programId: timeDelayMiddlewareProgram.programId,
         address: timeDelayMiddlewareAccount,
+        isSuperuser: false,
       },
     ];
 

--- a/packages/tests/src/middleware/checkDid.ts
+++ b/packages/tests/src/middleware/checkDid.ts
@@ -50,6 +50,7 @@ describe("Middleware: CheckDid", () => {
       {
         programId: checkDidMiddlewareProgram.programId,
         address: middlewareAccount,
+        isSuperuser: false,
       },
     ];
 

--- a/packages/tests/src/middleware/checkPass.ts
+++ b/packages/tests/src/middleware/checkPass.ts
@@ -154,6 +154,7 @@ describe("Middleware: checkPass", () => {
         cryptid.details.index,
         cryptid.details.didAccountBump,
         TransactionState.toBorsh(TransactionState.Ready),
+        false,
         [instruction],
         2
       )

--- a/packages/tests/src/middleware/checkPass.ts
+++ b/packages/tests/src/middleware/checkPass.ts
@@ -126,6 +126,7 @@ describe("Middleware: checkPass", () => {
       {
         programId: checkPassMiddlewareProgram.programId,
         address: middlewareAccount,
+        isSuperuser: false,
       },
     ];
 
@@ -174,7 +175,7 @@ describe("Middleware: checkPass", () => {
     // execute the Cryptid transaction
     program.methods
       .executeTransaction(
-        Buffer.from([]), // no controller chain
+        [], // no controller chain
         cryptid.details.bump,
         cryptid.details.index,
         cryptid.details.didAccountBump,

--- a/packages/tests/src/middleware/checkRecipient.ts
+++ b/packages/tests/src/middleware/checkRecipient.ts
@@ -66,6 +66,7 @@ describe("Middleware: checkRecipient", () => {
         {
           programId: checkRecipientMiddlewareProgram.programId,
           address: middlewareAccount,
+          isSuperuser: false,
         },
       ],
       { connection: provider.connection, accountIndex: ++cryptidIndex }
@@ -110,7 +111,7 @@ describe("Middleware: checkRecipient", () => {
       await cryptidWithoutMiddleware.propose(makeTransaction());
     await cryptidWithoutMiddleware.send(proposeTransaction, proposeSigners);
 
-    // send the execute tx - this will fail since the middeware was not used
+    // send the execute tx - this will fail since the middleware was not used
     const { executeTransactions, executeSigners } = await cryptid.execute(
       transactionAccount
     );

--- a/packages/tests/src/middleware/superuserCheckSigner.ts
+++ b/packages/tests/src/middleware/superuserCheckSigner.ts
@@ -1,0 +1,201 @@
+import {
+  Keypair,
+  LAMPORTS_PER_SOL,
+  PublicKey,
+  Transaction,
+  Signer,
+} from "@solana/web3.js";
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import { makeTransfer } from "../util/cryptid";
+import { initializeDIDAccount } from "../util/did";
+import { balanceOf, createTestContext, fund } from "../util/anchorUtils";
+import { DID_SOL_PREFIX } from "@identity.com/sol-did-client";
+import { Cryptid } from "@identity.com/cryptid";
+import {
+  SuperuserCheckSignerMiddleware,
+  deriveMiddlewareAccountAddress,
+} from "@identity.com/cryptid-middleware-superuser-check-signer";
+import { CryptidClient } from "@identity.com/cryptid-core";
+import { VersionedTransaction } from "@solana/web3.js";
+import { TransactionMessage } from "@solana/web3.js";
+
+chai.use(chaiAsPromised);
+const { expect } = chai;
+
+describe.only("Middleware: superuserCheckSigner", () => {
+  const {
+    keypair,
+    provider,
+    authority,
+    middleware: { superuserCheckSigner: superuserCheckSignerMiddlewareProgram },
+  } = createTestContext();
+
+  let cryptid: CryptidClient;
+  const cryptidIndex = 1;
+
+  let middlewareAccount: PublicKey;
+
+  let signer = Keypair.generate();
+
+  const makeTransaction = (to = signer.publicKey) =>
+    makeTransfer(cryptid.address(), to);
+
+  const convertToSignedVersionedTransaction = async (
+    tx: Transaction,
+    signers: Signer[] = []
+  ): Promise<VersionedTransaction> => {
+    const latestBlockhash = await provider.connection.getLatestBlockhash();
+    const messageV0 = new TransactionMessage({
+      payerKey: signer.publicKey,
+      recentBlockhash: latestBlockhash.blockhash,
+      instructions: tx.instructions,
+    }).compileToV0Message();
+    const transaction = new VersionedTransaction(messageV0);
+    transaction.sign([signer, ...signers]);
+    return transaction;
+  };
+
+  before("Fund the authority and signer", async () => {
+    await Promise.all([
+      fund(authority.publicKey, LAMPORTS_PER_SOL),
+      fund(signer.publicKey, LAMPORTS_PER_SOL),
+    ]);
+  });
+
+  before("Set up DID account", async () => {
+    await fund(authority.publicKey, 10 * LAMPORTS_PER_SOL);
+    await initializeDIDAccount(authority);
+  });
+
+  before("Set up middleware PDA", async () => {
+    [middlewareAccount] = deriveMiddlewareAccountAddress(
+      authority.publicKey,
+      signer.publicKey
+    );
+
+    const middlewareTx =
+      await new SuperuserCheckSignerMiddleware().createMiddleware({
+        signer: signer.publicKey,
+        authority,
+        connection: provider.connection,
+        opts: {},
+      });
+    await provider.sendAndConfirm(middlewareTx, [keypair]);
+  });
+
+  before(
+    "Set up Cryptid Account with middleware (this is signed by an authority on the DID)",
+    async () => {
+      const c = await Cryptid.createFromDID(
+        DID_SOL_PREFIX + ":" + authority.publicKey,
+        authority,
+        [
+          {
+            programId: superuserCheckSignerMiddlewareProgram.programId,
+            address: middlewareAccount,
+            isSuperuser: true,
+          },
+        ],
+        { connection: provider.connection, accountIndex: cryptidIndex }
+      );
+
+      console.log("Created Cryptid Account", c.address().toBase58());
+    }
+  );
+
+  before(
+    "Create a cryptid client with the non-did signer as an authority (so that it can propose unauthorised transactions for the superuser middleware to authorise)",
+    async () => {
+      cryptid = (
+        await Cryptid.buildFromDID(
+          DID_SOL_PREFIX + ":" + authority.publicKey,
+          signer,
+          {
+            connection: provider.connection,
+            accountIndex: cryptidIndex,
+            middlewares: [
+              {
+                programId: superuserCheckSignerMiddlewareProgram.programId,
+                address: middlewareAccount,
+                isSuperuser: true,
+              },
+            ],
+          }
+        )
+      ).unauthorized();
+
+      await fund(cryptid.address(), 20 * LAMPORTS_PER_SOL);
+
+      console.log("Funded Cryptid Account", cryptid.address().toBase58());
+    }
+  );
+
+  it.only("can execute a transfer if the tx is signed by the expected non-did signer", async () => {
+    const previousBalance = await balanceOf(cryptid.address());
+
+    console.log(
+      "Signer:",
+      signer.publicKey.toBase58(),
+      "balance",
+      await balanceOf(signer.publicKey)
+    );
+    console.log("Authority:", authority.publicKey.toBase58());
+
+    // propose the Cryptid transaction
+    const { proposeTransaction, transactionAccount, proposeSigners } =
+      await cryptid.propose(makeTransaction());
+    // this will be signed by the non-did signer
+    await cryptid.send(proposeTransaction, proposeSigners);
+
+    console.log("Proposed transaction", transactionAccount.toBase58());
+
+    // send the execute tx
+    const { executeTransactions } = await cryptid.execute(transactionAccount);
+    await cryptid.send(executeTransactions[0]);
+
+    const currentBalance = await balanceOf(cryptid.address());
+    expect(previousBalance - currentBalance).to.equal(LAMPORTS_PER_SOL); // Now the tx has been executed
+  });
+
+  it("blocks a transfer not passed by the middleware", async () => {
+    const cryptidWithoutMiddleware = Cryptid.build(
+      {
+        ...cryptid.details,
+        middlewares: [],
+      },
+      authority,
+      { connection: provider.connection }
+    );
+    // propose the Cryptid transaction
+    const { proposeTransaction, transactionAccount, proposeSigners } =
+      await cryptidWithoutMiddleware.propose(makeTransaction());
+    await cryptidWithoutMiddleware.send(proposeTransaction, proposeSigners);
+
+    // send the execute tx - this will fail since the middleware was not used
+    const { executeTransactions } = await cryptid.execute(transactionAccount);
+    const transaction = await convertToSignedVersionedTransaction(
+      executeTransactions[0]
+    );
+    await provider.connection.sendTransaction(transaction);
+    const shouldFail = cryptid.send(executeTransactions[0], [signer]);
+
+    return expect(shouldFail).to.be.rejectedWith(
+      "Error Code: IncorrectMiddleware"
+    );
+  });
+
+  it("blocks a transfer not signed by the signer", async () => {
+    // change the signer
+    signer = Keypair.generate();
+
+    // propose the Cryptid transaction. Since the superuserCheckSigner middleware
+    // executes on propose, this tx will fail
+    const { proposeTransaction, proposeSigners } = await cryptid.propose(
+      makeTransaction()
+    );
+    const shouldFail = cryptid.send(proposeTransaction, proposeSigners);
+
+    return expect(shouldFail).to.be.rejectedWith("Error Code: InvalidSigner.");
+  });
+});

--- a/packages/tests/src/middleware/timeDelay.ts
+++ b/packages/tests/src/middleware/timeDelay.ts
@@ -80,6 +80,7 @@ describe("Middleware: timeDelay", () => {
         {
           programId: timeDelayMiddlewareProgram.programId,
           address: slowMiddlewareAccount,
+          isSuperuser: false,
         },
       ],
       { connection: provider.connection, accountIndex: ++cryptidIndex }
@@ -92,6 +93,7 @@ describe("Middleware: timeDelay", () => {
         {
           programId: timeDelayMiddlewareProgram.programId,
           address: fastMiddlewareAccount,
+          isSuperuser: false,
         },
       ],
       { connection: provider.connection, accountIndex: ++cryptidIndex }

--- a/packages/tests/src/proposeExecute.ts
+++ b/packages/tests/src/proposeExecute.ts
@@ -55,6 +55,7 @@ didTestCases.forEach(({ didType, getDidAccount }) => {
             cryptid.details.index,
             cryptid.details.didAccountBump,
             TransactionState.toBorsh(TransactionState.Ready),
+            false,
             [instruction],
             2
           )
@@ -178,6 +179,7 @@ didTestCases.forEach(({ didType, getDidAccount }) => {
             cryptid.details.index,
             cryptid.details.didAccountBump,
             TransactionState.toBorsh(TransactionState.Ready),
+            false,
             [transferInstructionData],
             2
           )
@@ -334,6 +336,7 @@ didTestCases.forEach(({ didType, getDidAccount }) => {
             cryptid.details.index,
             cryptid.details.didAccountBump,
             TransactionState.toBorsh(TransactionState.Ready),
+            false,
             [transferInstructionData],
             2
           )

--- a/packages/tests/src/util/anchorUtils.ts
+++ b/packages/tests/src/util/anchorUtils.ts
@@ -7,6 +7,7 @@ import {
   CheckRecipient,
   Cryptid,
   TimeDelay,
+  SuperuserCheckSigner,
 } from "@identity.com/cryptid-idl";
 
 const envProvider = anchor.AnchorProvider.env();
@@ -20,6 +21,8 @@ const envCheckDidMiddlewareProgram = anchor.workspace
   .CheckDid as Program<CheckDid>;
 const envTimeDelayMiddlewareProgram = anchor.workspace
   .TimeDelay as Program<TimeDelay>;
+const envSuperuserCheckSignerMiddlewareProgram = anchor.workspace
+  .SuperuserCheckSigner as Program<SuperuserCheckSigner>;
 
 if (!process.env.QUIET) {
   const logListener = envProvider.connection.onLogs("all", (log) =>
@@ -66,6 +69,7 @@ export type CryptidTestContext = {
     checkPass: Program<CheckPass>;
     checkDid: Program<CheckDid>;
     timeDelay: Program<TimeDelay>;
+    superuserCheckSigner: Program<SuperuserCheckSigner>;
   };
 };
 
@@ -105,6 +109,12 @@ export const createTestContext = (): CryptidTestContext => {
     envTimeDelayMiddlewareProgram.programId,
     anchorProvider
   );
+  const superuserCheckSignerMiddlewareProgram =
+    new Program<SuperuserCheckSigner>(
+      envSuperuserCheckSignerMiddlewareProgram.idl,
+      envSuperuserCheckSignerMiddlewareProgram.programId,
+      anchorProvider
+    );
 
   return {
     program,
@@ -116,6 +126,7 @@ export const createTestContext = (): CryptidTestContext => {
       checkPass: checkPassMiddlewareProgram,
       checkDid: checkDidMiddlewareProgram,
       timeDelay: timeDelayMiddlewareProgram,
+      superuserCheckSigner: superuserCheckSignerMiddlewareProgram,
     },
   };
 };

--- a/packages/tests/src/util/cryptid.ts
+++ b/packages/tests/src/util/cryptid.ts
@@ -25,6 +25,7 @@ import {
 import BN from "bn.js";
 import { Wallet } from "./anchorUtils";
 import { TestType } from "./did";
+import { BuildOptions } from "@identity.com/cryptid-core/dist/api/cryptidClient";
 
 export const toAccountMeta = (
   publicKey: PublicKey,
@@ -174,7 +175,7 @@ export const cryptidTestCases = [
     getCryptidClient: async (
       did: string,
       authority: Wallet | Keypair,
-      options: CryptidOptions
+      options: BuildOptions
     ) => Builder.buildFromDID(did, authority, options),
   },
   {

--- a/programs/cryptid/src/error.rs
+++ b/programs/cryptid/src/error.rs
@@ -23,6 +23,9 @@ pub enum CryptidError {
     /// Invalid transaction state
     #[msg("Invalid transaction state")]
     InvalidTransactionState,
+    /// The transaction was proposed by a non-authority on the DID and has not been authorized by a superuser middleware.
+    #[msg("The transaction was proposed by a non-authority on the DID and has not been authorized by a superuser middleware.")]
+    UnauthorizedTransaction,
     /// An account in the transaction accounts did not match what was expected
     #[msg("An account in the transaction accounts did not match what was expected")]
     AccountMismatch,
@@ -46,6 +49,9 @@ pub enum CryptidError {
     /// The expected middleware did not approve the transaction
     #[msg("The expected middleware did not approve the transaction.")]
     IncorrectMiddleware,
+    /// The middleware is not registered as a superuser middleware on the cryptid account
+    #[msg("The middleware is not registered as a superuser middleware on the cryptid account.")]
+    IncorrectSuperuserMiddleware,
     /// The accounts passed to execute do not match those in the transaction account.
     #[msg("The accounts passed to execute do not match those in the transaction account.")]
     InvalidAccounts,

--- a/programs/cryptid/src/instructions/direct_execute.rs
+++ b/programs/cryptid/src/instructions/direct_execute.rs
@@ -89,6 +89,7 @@ pub fn direct_execute<'a, 'b, 'c, 'info>(
         did_account_bump,
         cryptid_account_index,
         cryptid_account_bump,
+        false,
     )?;
 
     // At this point, we are safe that the authority is a valid owner of the cryptid account. We can execute the instructions

--- a/programs/cryptid/src/instructions/execute_transaction.rs
+++ b/programs/cryptid/src/instructions/execute_transaction.rs
@@ -51,6 +51,8 @@ pub struct ExecuteTransaction<'info> {
     // only authorized transactions, ones that were proposed by a DID authority,
     // or authorized by a superuser middleware, can be executed
     constraint = transaction_account.authorized @ CryptidError::UnauthorizedTransaction,
+    // if the transaction was created
+    constraint = transaction_account.unauthorized_signer.unwrap_or(authority.key()) == authority.key() @ CryptidError::KeyMustBeSigner,
     // the transaction account must have been approved by the middleware on the cryptid account, if present
     // TODO: This moved to the instruction body
     // constraint = transaction_account.approved_middleware == cryptid_account.middleware @ CryptidError::IncorrectMiddleware,

--- a/programs/cryptid/src/instructions/execute_transaction.rs
+++ b/programs/cryptid/src/instructions/execute_transaction.rs
@@ -48,6 +48,9 @@ pub struct ExecuteTransaction<'info> {
     // safeguard to prevent double-spends in the case where the account is not closed for some reason
     // only "Ready" transactions can be executed
     constraint = transaction_account.state == TransactionState::Ready @ CryptidError::InvalidTransactionState,
+    // only authorized transactions, ones that were proposed by a DID authority,
+    // or authorized by a superuser middleware, can be executed
+    constraint = transaction_account.authorized @ CryptidError::UnauthorizedTransaction,
     // the transaction account must have been approved by the middleware on the cryptid account, if present
     // TODO: This moved to the instruction body
     // constraint = transaction_account.approved_middleware == cryptid_account.middleware @ CryptidError::IncorrectMiddleware,
@@ -93,6 +96,16 @@ pub fn execute_transaction<'a, 'b, 'c, 'info>(
         .unwrap()
         .contains(ExecuteFlags::DEBUG);
 
+    // if there is an unauthorized signer, it must be the one executing the transaction
+    // in this case, a superuser middleware must have authorized the transaction
+    if let Some(unauthorized_signer) = ctx.accounts.transaction_account.unauthorized_signer {
+        require_keys_eq!(
+            ctx.accounts.authority.key(),
+            unauthorized_signer,
+            CryptidError::KeyMustBeSigner
+        );
+    }
+
     let all_accounts = ctx.all_accounts();
 
     if debug {
@@ -105,6 +118,14 @@ pub fn execute_transaction<'a, 'b, 'c, 'info>(
             });
     }
 
+    // At this point, the transaction account signer has been checked to be the same as the authority
+    // and the tx has been approved by the middleware
+    // so we can assume that the transaction can be executed by the unauthorized signer, if there is one.
+    let allow_unauthorized_signer = ctx
+        .accounts
+        .transaction_account
+        .unauthorized_signer.is_some();
+
     let cryptid_account = get_cryptid_account_checked(
         &all_accounts,
         &controller_chain,
@@ -115,6 +136,8 @@ pub fn execute_transaction<'a, 'b, 'c, 'info>(
         did_account_bump,
         cryptid_account_index,
         cryptid_account_bump,
+
+        allow_unauthorized_signer,
     )?;
 
     // CHECK the accounts have not been switched since the transaction was proposed
@@ -125,6 +148,7 @@ pub fn execute_transaction<'a, 'b, 'c, 'info>(
     for ((index, account), proposed_account) in account_pairs {
         // The authority is allowed to change
         // As long as the authority is valid for the DID (checked above), any authority can sign the transaction.
+        msg!("Checking account {} {:?}", index, account.key);
         if index != AUTHORITY_ACCOUNT_INDEX {
             require_keys_eq!(
                 *account.key,

--- a/programs/cryptid/src/instructions/execute_transaction.rs
+++ b/programs/cryptid/src/instructions/execute_transaction.rs
@@ -52,7 +52,7 @@ pub struct ExecuteTransaction<'info> {
     // or authorized by a superuser middleware, can be executed
     constraint = transaction_account.authorized @ CryptidError::UnauthorizedTransaction,
     // if the transaction was created
-    constraint = transaction_account.unauthorized_signer.unwrap_or(authority.key()) == authority.key() @ CryptidError::KeyMustBeSigner,
+    constraint = transaction_account.unauthorized_signer.unwrap_or_else(|| authority.key()) == authority.key() @ CryptidError::KeyMustBeSigner,
     // the transaction account must have been approved by the middleware on the cryptid account, if present
     // TODO(ticket): Verification done in instruction body. Move back with Anchor generator
     // constraint = transaction_account.approved_middleware == cryptid_account.middleware @ CryptidError::IncorrectMiddleware,
@@ -126,7 +126,8 @@ pub fn execute_transaction<'a, 'b, 'c, 'info>(
     let allow_unauthorized_signer = ctx
         .accounts
         .transaction_account
-        .unauthorized_signer.is_some();
+        .unauthorized_signer
+        .is_some();
 
     let cryptid_account = get_cryptid_account_checked(
         &all_accounts,
@@ -138,7 +139,6 @@ pub fn execute_transaction<'a, 'b, 'c, 'info>(
         did_account_bump,
         cryptid_account_index,
         cryptid_account_bump,
-
         allow_unauthorized_signer,
     )?;
 

--- a/programs/cryptid/src/instructions/mod.rs
+++ b/programs/cryptid/src/instructions/mod.rs
@@ -2,6 +2,7 @@
 
 // pub mod cancel_transaction;
 pub mod approve_execution;
+pub mod superuser_approve_execution;
 pub mod create_cryptid_account;
 pub mod direct_execute;
 pub mod execute_transaction;
@@ -10,7 +11,9 @@ pub mod propose_transaction;
 
 pub mod util;
 
+
 pub use approve_execution::*;
+pub use superuser_approve_execution::*;
 pub use create_cryptid_account::*;
 pub use direct_execute::*;
 pub use execute_transaction::*;

--- a/programs/cryptid/src/instructions/mod.rs
+++ b/programs/cryptid/src/instructions/mod.rs
@@ -2,20 +2,19 @@
 
 // pub mod cancel_transaction;
 pub mod approve_execution;
-pub mod superuser_approve_execution;
 pub mod create_cryptid_account;
 pub mod direct_execute;
 pub mod execute_transaction;
 pub mod extend_transaction;
 pub mod propose_transaction;
+pub mod superuser_approve_execution;
 
 pub mod util;
 
-
 pub use approve_execution::*;
-pub use superuser_approve_execution::*;
 pub use create_cryptid_account::*;
 pub use direct_execute::*;
 pub use execute_transaction::*;
 pub use extend_transaction::*;
 pub use propose_transaction::*;
+pub use superuser_approve_execution::*;

--- a/programs/cryptid/src/instructions/superuser_approve_execution.rs
+++ b/programs/cryptid/src/instructions/superuser_approve_execution.rs
@@ -1,8 +1,8 @@
 use crate::error::CryptidError;
+use crate::state::cryptid_account::CryptidAccount;
 use crate::state::transaction_account::TransactionAccount;
 use crate::state::transaction_state::TransactionState;
 use anchor_lang::prelude::*;
-use crate::state::cryptid_account::CryptidAccount;
 
 #[derive(Accounts)]
 pub struct SuperuserApproveExecution<'info> {
@@ -12,11 +12,12 @@ pub struct SuperuserApproveExecution<'info> {
         // ensure the transaction is not approved until it is ready to be approved, and is not executed
         constraint = transaction_account.state == TransactionState::Ready @ CryptidError::InvalidTransactionState,
         has_one = cryptid_account,
-        constraint = transaction_account.authorized == false,
+        constraint = !transaction_account.authorized,
     )]
     pub transaction_account: Account<'info, TransactionAccount>,
     #[account(
-        constraint = cryptid_account.superuser_middleware.contains(&middleware_account.key) @ CryptidError::IncorrectSuperuserMiddleware,
+        // This instruction can only be used if the CryptidAccount allows it.
+        constraint = cryptid_account.superuser_middleware.contains(middleware_account.key) @ CryptidError::IncorrectSuperuserMiddleware,
     )]
     pub cryptid_account: Account<'info, CryptidAccount>,
 }
@@ -24,7 +25,15 @@ pub struct SuperuserApproveExecution<'info> {
 pub fn superuser_approve_execution<'a, 'b, 'c, 'info>(
     ctx: Context<'a, 'b, 'c, 'info, SuperuserApproveExecution<'info>>,
 ) -> Result<()> {
-    // TODO enforce that the middleware account belongs to an approved middleware program?
+    // Make sure owner is NOT the System Program
+    // TODO(ticket): Consider implementing an approval registry on middleware
+    require!(
+        !anchor_lang::solana_program::system_program::check_id(
+            ctx.accounts.middleware_account.owner
+        ),
+        CryptidError::InvalidMiddlewareAccount
+    );
+
     msg!(
         "Transaction approved by middleware owned by program: {}",
         ctx.accounts.middleware_account.owner
@@ -32,8 +41,17 @@ pub fn superuser_approve_execution<'a, 'b, 'c, 'info>(
     ctx.accounts.transaction_account.approved_middleware =
         Some(*ctx.accounts.middleware_account.key);
 
-    // TODO allow multiple superuser middlewares and require all to approve it.
-    ctx.accounts.transaction_account.authorized = true;
+    // only the LAST superuser_middleware is able to authorize the transaction
+    if ctx
+        .accounts
+        .cryptid_account
+        .superuser_middleware
+        .last()
+        .unwrap()
+        == ctx.accounts.middleware_account.key
+    {
+        ctx.accounts.transaction_account.authorized = true;
+    }
 
     Ok(())
 }

--- a/programs/cryptid/src/instructions/superuser_approve_execution.rs
+++ b/programs/cryptid/src/instructions/superuser_approve_execution.rs
@@ -1,0 +1,39 @@
+use crate::error::CryptidError;
+use crate::state::transaction_account::TransactionAccount;
+use crate::state::transaction_state::TransactionState;
+use anchor_lang::prelude::*;
+use crate::state::cryptid_account::CryptidAccount;
+
+#[derive(Accounts)]
+pub struct SuperuserApproveExecution<'info> {
+    pub middleware_account: Signer<'info>,
+    #[account(
+        mut,
+        // ensure the transaction is not approved until it is ready to be approved, and is not executed
+        constraint = transaction_account.state == TransactionState::Ready @ CryptidError::InvalidTransactionState,
+        has_one = cryptid_account,
+        constraint = transaction_account.authorized == false,
+    )]
+    pub transaction_account: Account<'info, TransactionAccount>,
+    #[account(
+        constraint = cryptid_account.superuser_middleware.contains(&middleware_account.key) @ CryptidError::IncorrectSuperuserMiddleware,
+    )]
+    pub cryptid_account: Account<'info, CryptidAccount>,
+}
+
+pub fn superuser_approve_execution<'a, 'b, 'c, 'info>(
+    ctx: Context<'a, 'b, 'c, 'info, SuperuserApproveExecution<'info>>,
+) -> Result<()> {
+    // TODO enforce that the middleware account belongs to an approved middleware program?
+    msg!(
+        "Transaction approved by middleware owned by program: {}",
+        ctx.accounts.middleware_account.owner
+    );
+    ctx.accounts.transaction_account.approved_middleware =
+        Some(*ctx.accounts.middleware_account.key);
+
+    // TODO allow multiple superuser middlewares and require all to approve it.
+    ctx.accounts.transaction_account.authorized = true;
+
+    Ok(())
+}

--- a/programs/cryptid/src/instructions/util.rs
+++ b/programs/cryptid/src/instructions/util.rs
@@ -2,8 +2,8 @@ use crate::error::CryptidError;
 use crate::state::cryptid_account::CryptidAccount;
 use crate::state::did_reference::DIDReference;
 use crate::util::SolDID;
-use anchor_lang::prelude::*;
 use anchor_lang::prelude::Error::AnchorError;
+use anchor_lang::prelude::*;
 use bitflags::bitflags;
 use sol_did::state::VerificationMethodType;
 

--- a/programs/cryptid/src/lib.rs
+++ b/programs/cryptid/src/lib.rs
@@ -25,6 +25,7 @@ pub mod cryptid {
     pub fn create_cryptid_account(
         ctx: Context<CreateCryptidAccount>,
         middleware: Option<Pubkey>,
+        superuser_middlewares: Vec<Pubkey>,
         controller_chain: Vec<Pubkey>,
         index: u32,
         did_account_bump: u8,
@@ -32,6 +33,7 @@ pub mod cryptid {
         instructions::create_cryptid_account(
             ctx,
             middleware,
+            superuser_middlewares,
             controller_chain,
             index,
             did_account_bump,

--- a/programs/cryptid/src/lib.rs
+++ b/programs/cryptid/src/lib.rs
@@ -67,6 +67,7 @@ pub mod cryptid {
         cryptid_account_index: u32,
         did_account_bump: u8,
         state: TransactionState,
+        allow_unauthorized: bool,
         instructions: Vec<AbbreviatedInstructionData>,
         _num_accounts: u8,
     ) -> Result<()> {
@@ -77,6 +78,7 @@ pub mod cryptid {
             cryptid_account_index,
             did_account_bump,
             state,
+            allow_unauthorized,
             instructions,
         )
     }
@@ -88,6 +90,7 @@ pub mod cryptid {
         cryptid_account_index: u32,
         did_account_bump: u8,
         state: TransactionState,
+        allow_unauthorized: bool,
         instructions: Vec<AbbreviatedInstructionData>,
         _num_accounts: u8,
     ) -> Result<()> {
@@ -98,6 +101,7 @@ pub mod cryptid {
             cryptid_account_index,
             did_account_bump,
             state,
+            allow_unauthorized,
             instructions,
         )
     }
@@ -124,5 +128,11 @@ pub mod cryptid {
         ctx: Context<'a, 'b, 'c, 'info, ApproveExecution<'info>>,
     ) -> Result<()> {
         instructions::approve_execution(ctx)
+    }
+
+    pub fn superuser_approve_execution<'a, 'b, 'c, 'info>(
+        ctx: Context<'a, 'b, 'c, 'info, SuperuserApproveExecution<'info>>,
+    ) -> Result<()> {
+        instructions::superuser_approve_execution(ctx)
     }
 }

--- a/programs/cryptid/src/state/cryptid_account.rs
+++ b/programs/cryptid/src/state/cryptid_account.rs
@@ -9,11 +9,16 @@ pub struct CryptidAccount {
     pub middleware: Option<Pubkey>,
     /// The index of this cryptid account - allows multiple cryptid accounts per DID
     pub index: u32,
+    /// Middlewares that have "Superuser" status on the cryptid account
+    pub superuser_middleware: Vec<Pubkey>,
 }
 impl CryptidAccount {
     pub const SEED_PREFIX: &'static [u8] = b"cryptid_account";
 
-    pub const MAX_SIZE: usize = (1 + 32) + 4;
+    pub const BASE_SIZE: usize = (1 + 32) + 4;
+    pub fn calculate_size(superuser_middleware_count: usize) -> usize {
+        Self::BASE_SIZE + 4 + (32 * superuser_middleware_count)
+    }
 
     // Support generative and non-generative accounts
     pub fn try_from(
@@ -34,6 +39,7 @@ impl CryptidAccount {
             return Ok(CryptidAccount {
                 middleware: None,
                 index,
+                superuser_middleware: vec![],
             });
         }
 

--- a/programs/cryptid/src/state/transaction_account.rs
+++ b/programs/cryptid/src/state/transaction_account.rs
@@ -27,6 +27,12 @@ pub struct TransactionAccount {
     /// in case an executed transaction account is not immediately
     /// garbage-collected by the runtime
     pub state: TransactionState,
+    /// If the transaction account is proposed by an authority on the DID, (the standard case)
+    /// then this is set to None.
+    /// If the transaction account is proposed by an unauthorized cryptid client, then
+    /// it is set to to that signer, and only a `superUser` middleware can approve it.
+    pub unauthorized_signer: Option<Pubkey>,
+    pub authorized: bool,
 }
 impl TransactionAccount {
     /// Calculates the on-chain size of a [`TransactionAccount`]
@@ -42,6 +48,8 @@ impl TransactionAccount {
             + 1 + 32 // approved_middleware
             + 1 // slot
             + 1 // state
+            + 1 + 32 // unauthorized signer
+            + 1 // authorized
     }
 
     pub fn check_account(&self, index: u8, account: &Pubkey) -> Result<()> {
@@ -99,6 +107,8 @@ mod test {
             approved_middleware: None,
             slot: 0,
             state: TransactionState::Ready,
+            unauthorized_signer: None,
+            authorized: true,
         };
         let ser_size = BorshSerialize::try_to_vec(&account).unwrap().len();
         println!("SerSize: {}", ser_size);

--- a/programs/middleware/superuser_check_signer/Cargo.toml
+++ b/programs/middleware/superuser_check_signer/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "superuser_check_signer"
+version = "0.1.0"
+description = "Created with Anchor"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "superuser_check_signer"
+
+[features]
+no-entrypoint = []
+no-idl = []
+no-log-ix-name = []
+cpi = ["no-entrypoint"]
+default = []
+
+[dependencies]
+anchor-lang = "0.26.0"
+cryptid = { path = "../../cryptid", features = ["no-entrypoint", "cpi"] }

--- a/programs/middleware/superuser_check_signer/Xargo.toml
+++ b/programs/middleware/superuser_check_signer/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/programs/middleware/superuser_check_signer/src/lib.rs
+++ b/programs/middleware/superuser_check_signer/src/lib.rs
@@ -31,6 +31,9 @@ pub mod superuser_check_signer {
     /// Note- there is no additional check needed here - the signer check is already verified
     /// by anchor.
     pub fn execute_middleware(ctx: Context<ExecuteMiddleware>) -> Result<()> {
+        msg!("Set signer: {}", ctx.accounts.middleware_account.signer);
+        msg!("Passed signer: {}", ctx.accounts.signer.key);
+
         // Check the previous middleware has passed the transaction
         if let Some(required_previous_middleware) =
             ctx.accounts.middleware_account.previous_middleware

--- a/programs/middleware/superuser_check_signer/src/lib.rs
+++ b/programs/middleware/superuser_check_signer/src/lib.rs
@@ -1,0 +1,149 @@
+#![allow(clippy::result_large_err)]
+extern crate core;
+
+use anchor_lang::prelude::*;
+use cryptid::cpi::accounts::SuperuserApproveExecution;
+use cryptid::error::CryptidError;
+use cryptid::program::Cryptid;
+use cryptid::state::cryptid_account::CryptidAccount;
+use cryptid::state::transaction_account::TransactionAccount;
+
+declare_id!("midsEy2qfSX1gguxZT3Kv4dGTDisi7iDMAJfSmyG5Y9");
+
+#[program]
+pub mod superuser_check_signer {
+    use super::*;
+
+    pub fn create(
+        ctx: Context<Create>,
+        signer: Pubkey,
+        bump: u8,
+        previous_middleware: Option<Pubkey>,
+    ) -> Result<()> {
+        ctx.accounts.middleware_account.signer = signer;
+        ctx.accounts.middleware_account.authority = *ctx.accounts.authority.key;
+        ctx.accounts.middleware_account.bump = bump;
+        ctx.accounts.middleware_account.previous_middleware = previous_middleware;
+        Ok(())
+    }
+
+    /// execute the middleware - checking that any previous middleware have been executed
+    /// Note- there is no additional check needed here - the signer check is already verified
+    /// by anchor.
+    pub fn execute_middleware(ctx: Context<ExecuteMiddleware>) -> Result<()> {
+        // Check the previous middleware has passed the transaction
+        if let Some(required_previous_middleware) =
+            ctx.accounts.middleware_account.previous_middleware
+        {
+            match ctx.accounts.transaction_account.approved_middleware {
+                None => err!(CryptidError::IncorrectMiddleware),
+                Some(approved_previous_middleware) => {
+                    require_keys_eq!(
+                        required_previous_middleware,
+                        approved_previous_middleware,
+                        CryptidError::IncorrectMiddleware
+                    );
+                    Ok(())
+                }
+            }?;
+        }
+        ExecuteMiddleware::approve(ctx)
+    }
+}
+
+#[derive(Accounts)]
+#[instruction(
+/// The signer that the middleware will allow to sign a transaction, bypassing the DID key check
+signer: Pubkey,
+/// The bump seed for the middleware pda
+bump: u8,
+/// The previous middleware account, if any.
+previous_middleware: Option<Pubkey>
+)]
+pub struct Create<'info> {
+    #[account(
+        init,
+        payer = authority,
+        space = 8 + SuperuserCheckSigner::MAX_SIZE,
+        seeds = [
+            SuperuserCheckSigner::SEED_PREFIX,
+            authority.key().as_ref(),
+            signer.as_ref(),
+            previous_middleware.as_ref().map(|p| p.as_ref()).unwrap_or(&[0u8; 32])
+        ],
+        bump,
+    )]
+    pub middleware_account: Account<'info, SuperuserCheckSigner>,
+    #[account(mut)]
+    pub authority: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct ExecuteMiddleware<'info> {
+    #[account(
+        has_one = signer @ ErrorCode::InvalidSigner
+    )]
+    pub middleware_account: Account<'info, SuperuserCheckSigner>,
+    #[account(
+        mut,
+        has_one = cryptid_account,
+    )]
+    pub transaction_account: Account<'info, TransactionAccount>,
+    pub cryptid_account: Account<'info, CryptidAccount>,
+    pub signer: Signer<'info>,
+    pub cryptid_program: Program<'info, Cryptid>,
+}
+impl<'info> ExecuteMiddleware<'info> {
+    // TODO abstract this into shared?
+    pub fn approve(ctx: Context<ExecuteMiddleware>) -> Result<()> {
+        let cpi_program = ctx.accounts.cryptid_program.to_account_info();
+        let cpi_accounts = SuperuserApproveExecution {
+            middleware_account: ctx.accounts.middleware_account.to_account_info(),
+            transaction_account: ctx.accounts.transaction_account.to_account_info(),
+            cryptid_account: ctx.accounts.cryptid_account.to_account_info(),
+        };
+        // define seeds inline here rather than extract to a function
+        // in order to avoid having to convert Vec<Vec<u8>> to &[&[u8]]
+        let authority_key = ctx.accounts.middleware_account.authority.key();
+        let signer = ctx.accounts.middleware_account.signer.key();
+        let previous_middleware = ctx
+            .accounts
+            .middleware_account
+            .previous_middleware
+            .as_ref()
+            .map(|p| p.as_ref())
+            .unwrap_or(&[0u8; 32]);
+        let bump = ctx.accounts.middleware_account.bump.to_le_bytes();
+        let seeds = &[
+            SuperuserCheckSigner::SEED_PREFIX,
+            authority_key.as_ref(),
+            signer.as_ref(),
+            previous_middleware,
+            bump.as_ref(),
+        ][..];
+        let signer = &[seeds][..];
+        let cpi_ctx = CpiContext::new_with_signer(cpi_program, cpi_accounts, signer);
+        cryptid::cpi::superuser_approve_execution(cpi_ctx)
+    }
+}
+
+#[account()]
+pub struct SuperuserCheckSigner {
+    pub signer: Pubkey,
+    pub authority: Pubkey,
+    pub bump: u8,
+    /// The previous middleware in the chain, if any
+    pub previous_middleware: Option<Pubkey>,
+}
+impl SuperuserCheckSigner {
+    pub const SEED_PREFIX: &'static [u8] = b"superuser_check_signer";
+
+    pub const MAX_SIZE: usize = 32 + 32 + 1 + (1 + 32);
+}
+
+#[error_code]
+pub enum ErrorCode {
+    #[msg("The middleware execution was signed by the wrong signer")]
+    InvalidSigner,
+}


### PR DESCRIPTION
Add the ability for superuser middleware:

Sample use case.

Alice has a cryptid account. She sends $100 to it and authorises Bob to withdraw $5 per month.

This will happen with the following middleware:

* Superuser Middleware to allow Bob to withdraw
Middleware with a spending limit per month

The superuser middleware bypasses the DID authority check when executing a tx