### PR TITLE
Security Audit Feedback - Bugfix

### DIFF
--- a/packages/client/core/src/api/unauthorizedCryptidClient.ts
+++ b/packages/client/core/src/api/unauthorizedCryptidClient.ts
@@ -1,7 +1,7 @@
 import { CryptidClient, CryptidOptions } from "./cryptidClient";
 import { Wallet } from "../types/crypto";
 import { CryptidAccountDetails } from "../lib/CryptidAccountDetails";
-import { PublicKey, Transaction } from "@solana/web3.js";
+import { Transaction } from "@solana/web3.js";
 import { ProposalResult, TransactionState } from "../types/cryptid";
 import { AbstractCryptidClient } from "./abstractCryptidClient";
 import { ControlledCryptidClient } from "./controlledCryptidClient";
@@ -39,22 +39,6 @@ export class UnauthorizedCryptidClient extends AbstractCryptidClient {
   ): Promise<ProposalResult> {
     return this.service().then((service) =>
       service.propose(this.details, transaction, state, true)
-    );
-  }
-
-  async extend(
-    transactionAccountAddress: PublicKey,
-    transaction: Transaction,
-    state?: TransactionState
-  ): Promise<Transaction> {
-    return this.service().then((service) =>
-      service.extend(
-        this.details,
-        transactionAccountAddress,
-        transaction,
-        state,
-        true
-      )
     );
   }
 

--- a/packages/client/core/src/lib/CryptidTransaction.ts
+++ b/packages/client/core/src/lib/CryptidTransaction.ts
@@ -298,15 +298,13 @@ export class CryptidTransaction {
    * @param program
    * @param transactionAccountAddress
    * @param state
-   * @param allowUnauthorized
    */
   // TODO move transactionAccountAddress into constructor?
   extend(
     program: Program<Cryptid>,
     transactionAccountAddress: PublicKey,
     // by default, extend the transaction and seal it at the same time
-    state = TransactionState.Ready,
-    allowUnauthorized = false
+    state = TransactionState.Ready
   ) {
     return (
       program.methods
@@ -316,7 +314,6 @@ export class CryptidTransaction {
           this.cryptidAccount.index,
           this.cryptidAccount.didAccountBump,
           TransactionState.toBorsh(state),
-          allowUnauthorized,
           this.instructions,
           this.accountMetas.length
         )

--- a/packages/client/core/src/service/cryptid.ts
+++ b/packages/client/core/src/service/cryptid.ts
@@ -314,8 +314,7 @@ export class CryptidService {
     account: CryptidAccountDetails,
     transactionAccountAddress: PublicKey,
     transaction: Transaction,
-    state?: TransactionState,
-    allowUnauthorized = false
+    state?: TransactionState
   ): Promise<Transaction> {
     const cryptidTransaction = CryptidTransaction.fromSolanaInstructions(
       account,
@@ -327,8 +326,7 @@ export class CryptidService {
     let builder = cryptidTransaction.extend(
       this.program,
       transactionAccountAddress,
-      state,
-      allowUnauthorized
+      state
     );
 
     if (state === TransactionState.Ready) {

--- a/packages/client/idl/src/cryptid.ts
+++ b/packages/client/idl/src/cryptid.ts
@@ -299,10 +299,6 @@ export type Cryptid = {
           }
         },
         {
-          "name": "allowUnauthorized",
-          "type": "bool"
-        },
-        {
           "name": "instructions",
           "type": {
             "vec": {
@@ -853,6 +849,11 @@ export type Cryptid = {
       "code": 6016,
       "name": "InvalidMiddlewareAccount",
       "msg": "Approve Execution needs to be called with a valid Middleware Account."
+    },
+    {
+      "code": 6017,
+      "name": "AlreadyAuthorizedTransactionAccount",
+      "msg": "Already authorized Transaction Account."
     }
   ]
 };
@@ -1158,10 +1159,6 @@ export const IDL: Cryptid = {
           }
         },
         {
-          "name": "allowUnauthorized",
-          "type": "bool"
-        },
-        {
           "name": "instructions",
           "type": {
             "vec": {
@@ -1712,6 +1709,11 @@ export const IDL: Cryptid = {
       "code": 6016,
       "name": "InvalidMiddlewareAccount",
       "msg": "Approve Execution needs to be called with a valid Middleware Account."
+    },
+    {
+      "code": 6017,
+      "name": "AlreadyAuthorizedTransactionAccount",
+      "msg": "Already authorized Transaction Account."
     }
   ]
 };

--- a/programs/cryptid/src/error.rs
+++ b/programs/cryptid/src/error.rs
@@ -58,4 +58,7 @@ pub enum CryptidError {
     /// An invalid Middleware Account was passed.
     #[msg("Approve Execution needs to be called with a valid Middleware Account.")]
     InvalidMiddlewareAccount,
+    /// Already authorized Transaction Account.
+    #[msg("Transaction Account is already authorized and cannot be authorized again.")]
+    AlreadyAuthorizedTransactionAccount,
 }

--- a/programs/cryptid/src/instructions/approve_execution.rs
+++ b/programs/cryptid/src/instructions/approve_execution.rs
@@ -15,8 +15,8 @@ pub struct ApproveExecution<'info> {
 }
 
 /// Executes a transaction directly if all required keys sign
-pub fn approve_execution<'a, 'b, 'c, 'info>(
-    ctx: Context<'a, 'b, 'c, 'info, ApproveExecution<'info>>,
+pub fn approve_execution<'info>(
+    ctx: Context<'_, '_, '_, 'info, ApproveExecution<'info>>,
 ) -> Result<()> {
     // Make sure owner is NOT the System Program
     // TODO(ticket): Consider implementing an approval registry on middleware

--- a/programs/cryptid/src/instructions/close_transaction.rs
+++ b/programs/cryptid/src/instructions/close_transaction.rs
@@ -77,8 +77,8 @@ impl<'a, 'b, 'c, 'info> AllAccounts<'a, 'b, 'c, 'info>
 }
 
 /// Close an existing transaction account
-pub fn close_transaction<'a, 'b, 'c, 'info>(
-    ctx: Context<'a, 'b, 'c, 'info, CloseTransaction<'info>>,
+pub fn close_transaction<'info>(
+    ctx: Context<'_, '_, '_, 'info, CloseTransaction<'info>>,
     controller_chain: Vec<DIDReference>,
     cryptid_account_bump: u8,
     cryptid_account_index: u32,

--- a/programs/cryptid/src/instructions/direct_execute.rs
+++ b/programs/cryptid/src/instructions/direct_execute.rs
@@ -61,8 +61,8 @@ impl<'a, 'b, 'c, 'info> AllAccounts<'a, 'b, 'c, 'info>
 }
 
 /// Executes a transaction directly if all required keys sign
-pub fn direct_execute<'a, 'b, 'c, 'info>(
-    ctx: Context<'a, 'b, 'c, 'info, DirectExecute<'info>>,
+pub fn direct_execute<'info>(
+    ctx: Context<'_, '_, '_, 'info, DirectExecute<'info>>,
     controller_chain: Vec<DIDReference>,
     instructions: Vec<AbbreviatedInstructionData>,
     cryptid_account_bump: u8,

--- a/programs/cryptid/src/instructions/execute_transaction.rs
+++ b/programs/cryptid/src/instructions/execute_transaction.rs
@@ -86,8 +86,8 @@ impl<'a, 'b, 'c, 'info> AllAccounts<'a, 'b, 'c, 'info>
 }
 
 /// Executes a transaction directly if all required keys sign
-pub fn execute_transaction<'a, 'b, 'c, 'info>(
-    ctx: Context<'a, 'b, 'c, 'info, ExecuteTransaction<'info>>,
+pub fn execute_transaction<'info>(
+    ctx: Context<'_, '_, '_, 'info, ExecuteTransaction<'info>>,
     controller_chain: Vec<DIDReference>,
     cryptid_account_bump: u8,
     cryptid_account_index: u32,

--- a/programs/cryptid/src/instructions/propose_transaction.rs
+++ b/programs/cryptid/src/instructions/propose_transaction.rs
@@ -81,8 +81,8 @@ impl<'a, 'b, 'c, 'info> AllAccounts<'a, 'b, 'c, 'info>
 
 /// Propose a transaction to be executed by a cryptid account
 /// Note - at present, there is no constraint on who can propose a transaction.
-pub fn propose_transaction<'a, 'b, 'c, 'info>(
-    ctx: Context<'a, 'b, 'c, 'info, ProposeTransaction<'info>>,
+pub fn propose_transaction<'info>(
+    ctx: Context<'_, '_, '_, 'info, ProposeTransaction<'info>>,
     controller_chain: Vec<DIDReference>,
     cryptid_account_bump: u8,
     cryptid_account_index: u32,

--- a/programs/cryptid/src/instructions/superuser_approve_execution.rs
+++ b/programs/cryptid/src/instructions/superuser_approve_execution.rs
@@ -12,7 +12,7 @@ pub struct SuperuserApproveExecution<'info> {
         // ensure the transaction is not approved until it is ready to be approved, and is not executed
         constraint = transaction_account.state == TransactionState::Ready @ CryptidError::InvalidTransactionState,
         has_one = cryptid_account,
-        constraint = !transaction_account.authorized,
+        constraint = !transaction_account.authorized @ CryptidError::AlreadyAuthorizedTransactionAccount,
     )]
     pub transaction_account: Account<'info, TransactionAccount>,
     #[account(
@@ -22,8 +22,8 @@ pub struct SuperuserApproveExecution<'info> {
     pub cryptid_account: Account<'info, CryptidAccount>,
 }
 
-pub fn superuser_approve_execution<'a, 'b, 'c, 'info>(
-    ctx: Context<'a, 'b, 'c, 'info, SuperuserApproveExecution<'info>>,
+pub fn superuser_approve_execution<'info>(
+    ctx: Context<'_, '_, '_, 'info, SuperuserApproveExecution<'info>>,
 ) -> Result<()> {
     // Make sure owner is NOT the System Program
     // TODO(ticket): Consider implementing an approval registry on middleware

--- a/programs/cryptid/src/instructions/util.rs
+++ b/programs/cryptid/src/instructions/util.rs
@@ -32,11 +32,11 @@ pub fn resolve_by_index<'c, 'info>(
 /// Verifies that the signer has the permission to sign for the DID
 /// If the controller-chain is empty, it expects the signer to be a key on the did itself
 /// Otherwise, the signer is a signer on a controller of the DID (either directly or indirectly)
-pub fn verify_keys<'info1, 'info2>(
-    did: &AccountInfo<'info1>,
+pub fn verify_keys(
+    did: &AccountInfo<'_>,
     did_account_bump: Option<u8>,
     signer: &Pubkey,
-    controlling_did_accounts: Vec<(&AccountInfo<'info2>, Pubkey)>,
+    controlling_did_accounts: Vec<(&AccountInfo<'_>, Pubkey)>,
 ) -> Result<()> {
     let signer_is_authority = sol_did::integrations::is_authority(
         did,

--- a/programs/cryptid/src/lib.rs
+++ b/programs/cryptid/src/lib.rs
@@ -40,8 +40,8 @@ pub mod cryptid {
         )
     }
 
-    pub fn direct_execute<'a, 'b, 'c, 'info>(
-        ctx: Context<'a, 'b, 'c, 'info, DirectExecute<'info>>,
+    pub fn direct_execute<'info>(
+        ctx: Context<'_, '_, '_, 'info, DirectExecute<'info>>,
         controller_chain: Vec<DIDReference>,
         instructions: Vec<AbbreviatedInstructionData>,
         cryptid_account_bump: u8,
@@ -60,8 +60,8 @@ pub mod cryptid {
         )
     }
 
-    pub fn propose_transaction<'a, 'b, 'c, 'info>(
-        ctx: Context<'a, 'b, 'c, 'info, ProposeTransaction<'info>>,
+    pub fn propose_transaction<'info>(
+        ctx: Context<'_, '_, '_, 'info, ProposeTransaction<'info>>,
         controller_chain: Vec<DIDReference>,
         cryptid_account_bump: u8,
         cryptid_account_index: u32,
@@ -83,14 +83,13 @@ pub mod cryptid {
         )
     }
 
-    pub fn extend_transaction<'a, 'b, 'c, 'info>(
-        ctx: Context<'a, 'b, 'c, 'info, ExtendTransaction<'info>>,
+    pub fn extend_transaction<'info>(
+        ctx: Context<'_, '_, '_, 'info, ExtendTransaction<'info>>,
         controller_chain: Vec<DIDReference>,
         cryptid_account_bump: u8,
         cryptid_account_index: u32,
         did_account_bump: u8,
         state: TransactionState,
-        allow_unauthorized: bool,
         instructions: Vec<AbbreviatedInstructionData>,
         _num_accounts: u8,
     ) -> Result<()> {
@@ -101,13 +100,12 @@ pub mod cryptid {
             cryptid_account_index,
             did_account_bump,
             state,
-            allow_unauthorized,
             instructions,
         )
     }
 
-    pub fn execute_transaction<'a, 'b, 'c, 'info>(
-        ctx: Context<'a, 'b, 'c, 'info, ExecuteTransaction<'info>>,
+    pub fn execute_transaction<'info>(
+        ctx: Context<'_, '_, '_, 'info, ExecuteTransaction<'info>>,
         controller_chain: Vec<DIDReference>,
         cryptid_account_bump: u8,
         cryptid_account_index: u32,
@@ -124,8 +122,8 @@ pub mod cryptid {
         )
     }
 
-    pub fn close_transaction<'a, 'b, 'c, 'info>(
-        ctx: Context<'a, 'b, 'c, 'info, CloseTransaction<'info>>,
+    pub fn close_transaction<'info>(
+        ctx: Context<'_, '_, '_, 'info, CloseTransaction<'info>>,
         controller_chain: Vec<DIDReference>,
         cryptid_account_bump: u8,
         cryptid_account_index: u32,
@@ -140,14 +138,14 @@ pub mod cryptid {
         )
     }
 
-    pub fn approve_execution<'a, 'b, 'c, 'info>(
-        ctx: Context<'a, 'b, 'c, 'info, ApproveExecution<'info>>,
+    pub fn approve_execution<'info>(
+        ctx: Context<'_, '_, '_, 'info, ApproveExecution<'info>>,
     ) -> Result<()> {
         instructions::approve_execution(ctx)
     }
 
-    pub fn superuser_approve_execution<'a, 'b, 'c, 'info>(
-        ctx: Context<'a, 'b, 'c, 'info, SuperuserApproveExecution<'info>>,
+    pub fn superuser_approve_execution<'info>(
+        ctx: Context<'_, '_, '_, 'info, SuperuserApproveExecution<'info>>,
     ) -> Result<()> {
         instructions::superuser_approve_execution(ctx)
     }

--- a/programs/cryptid/src/state/abbreviated_instruction_data.rs
+++ b/programs/cryptid/src/state/abbreviated_instruction_data.rs
@@ -74,7 +74,7 @@ impl fmt::Display for AbbreviatedInstructionData {
         writeln!(f, "Program: {}", self.program_id)?;
         writeln!(f, "Accounts:")?;
         for account in self.accounts.iter() {
-            writeln!(f, "  {}", account)?;
+            writeln!(f, "  {account}")?;
         }
         write!(f, "Data: {:?}", self.data)?;
         Ok(())

--- a/programs/cryptid/src/state/transaction_account.rs
+++ b/programs/cryptid/src/state/transaction_account.rs
@@ -65,11 +65,11 @@ impl fmt::Display for TransactionAccount {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "Accounts:")?;
         for (index, account) in self.accounts.iter().enumerate() {
-            writeln!(f, "{}: {}", index, account)?;
+            writeln!(f, "{index}: {account}")?;
         }
         for (index, instruction) in self.instructions.iter().enumerate() {
-            writeln!(f, "Instruction {}:", index)?;
-            writeln!(f, "{}", instruction)?;
+            writeln!(f, "Instruction {index}:",)?;
+            writeln!(f, "{instruction}",)?;
         }
         Ok(())
     }
@@ -92,7 +92,7 @@ mod test {
                 data_len: 1,
             }),
         );
-        println!("Size: {}", size);
+        println!("Size: {size}");
 
         let account = TransactionAccount {
             cryptid_account: Default::default(),
@@ -110,7 +110,7 @@ mod test {
             authorized: true,
         };
         let ser_size = BorshSerialize::try_to_vec(&account).unwrap().len();
-        println!("SerSize: {}", ser_size);
+        println!("SerSize: {ser_size}");
         assert_eq!(size, ser_size);
     }
 }


### PR DESCRIPTION
Issue: **ATTACKER CAN EXTEND A TRANSACTION THEY DO NOT HAVE THE AUTHORITY OF**

The intended functionality of the ExtendTransaction instruction is to allow privileged user’s (authorized signers and allowed unauthorized signers) the ability to extend a transaction. Under certain conditions, an attacker can successfully extend the transaction of another user.

This fixes the disclosed issue.