### PR TITLE
Fix permissionless middleware approving by whitelisting middleware programs in propose.

### DIFF
--- a/packages/client/core/src/lib/CryptidTransaction.ts
+++ b/packages/client/core/src/lib/CryptidTransaction.ts
@@ -278,6 +278,7 @@ export class CryptidTransaction {
           this.cryptidAccount.didAccountBump,
           TransactionState.toBorsh(state),
           allowUnauthorized,
+          this.cryptidAccount.middlewares.map((m) => m.programId),
           this.instructions,
           this.accountMetas.length
         )

--- a/packages/client/idl/src/cryptid.ts
+++ b/packages/client/idl/src/cryptid.ts
@@ -215,6 +215,12 @@ export type Cryptid = {
           "type": "bool"
         },
         {
+          "name": "whitelistedMiddlewarePrograms",
+          "type": {
+            "vec": "publicKey"
+          }
+        },
+        {
           "name": "instructions",
           "type": {
             "vec": {
@@ -587,14 +593,6 @@ export type Cryptid = {
             }
           },
           {
-            "name": "slot",
-            "docs": [
-              "The slot in which the transaction was proposed",
-              "This is used to prevent replay attacks"
-            ],
-            "type": "u8"
-          },
-          {
             "name": "state",
             "docs": [
               "The transaction state, to prevent replay attacks",
@@ -615,6 +613,17 @@ export type Cryptid = {
             ],
             "type": {
               "option": "publicKey"
+            }
+          },
+          {
+            "name": "whitelistedMiddlewarePrograms",
+            "docs": [
+              "This vector contains a list of middleware program ids that are allowed to",
+              "approve the execution. Important, is not used for passing transactions execution",
+              "checks. (approved_middleware: Option<Pubkey>) is used for that."
+            ],
+            "type": {
+              "vec": "publicKey"
             }
           },
           {
@@ -853,7 +862,7 @@ export type Cryptid = {
     {
       "code": 6017,
       "name": "AlreadyAuthorizedTransactionAccount",
-      "msg": "Already authorized Transaction Account."
+      "msg": "Transaction Account is already authorized and cannot be authorized again."
     }
   ]
 };
@@ -1075,6 +1084,12 @@ export const IDL: Cryptid = {
           "type": "bool"
         },
         {
+          "name": "whitelistedMiddlewarePrograms",
+          "type": {
+            "vec": "publicKey"
+          }
+        },
+        {
           "name": "instructions",
           "type": {
             "vec": {
@@ -1447,14 +1462,6 @@ export const IDL: Cryptid = {
             }
           },
           {
-            "name": "slot",
-            "docs": [
-              "The slot in which the transaction was proposed",
-              "This is used to prevent replay attacks"
-            ],
-            "type": "u8"
-          },
-          {
             "name": "state",
             "docs": [
               "The transaction state, to prevent replay attacks",
@@ -1475,6 +1482,17 @@ export const IDL: Cryptid = {
             ],
             "type": {
               "option": "publicKey"
+            }
+          },
+          {
+            "name": "whitelistedMiddlewarePrograms",
+            "docs": [
+              "This vector contains a list of middleware program ids that are allowed to",
+              "approve the execution. Important, is not used for passing transactions execution",
+              "checks. (approved_middleware: Option<Pubkey>) is used for that."
+            ],
+            "type": {
+              "vec": "publicKey"
             }
           },
           {
@@ -1713,7 +1731,7 @@ export const IDL: Cryptid = {
     {
       "code": 6017,
       "name": "AlreadyAuthorizedTransactionAccount",
-      "msg": "Already authorized Transaction Account."
+      "msg": "Transaction Account is already authorized and cannot be authorized again."
     }
   ]
 };

--- a/packages/tests/src/proposeExecute.ts
+++ b/packages/tests/src/proposeExecute.ts
@@ -56,6 +56,7 @@ didTestCases.forEach(({ didType, getDidAccount }) => {
             cryptid.details.didAccountBump,
             TransactionState.toBorsh(TransactionState.Ready),
             false,
+            [], // no whitelisted middleware programs
             [instruction],
             2
           )
@@ -178,6 +179,7 @@ didTestCases.forEach(({ didType, getDidAccount }) => {
             cryptid.details.didAccountBump,
             TransactionState.toBorsh(TransactionState.Ready),
             false,
+            [], // no whitelisted middleware programs
             [transferInstructionData],
             2
           )
@@ -337,6 +339,7 @@ didTestCases.forEach(({ didType, getDidAccount }) => {
             cryptid.details.didAccountBump,
             TransactionState.toBorsh(TransactionState.Ready),
             false,
+            [], // no whitelisted middleware programs
             [transferInstructionData],
             2
           )

--- a/programs/cryptid/src/instructions/approve_execution.rs
+++ b/programs/cryptid/src/instructions/approve_execution.rs
@@ -18,12 +18,11 @@ pub struct ApproveExecution<'info> {
 pub fn approve_execution<'info>(
     ctx: Context<'_, '_, '_, 'info, ApproveExecution<'info>>,
 ) -> Result<()> {
-    // Make sure owner is NOT the System Program
-    // TODO(ticket): Consider implementing an approval registry on middleware
     require!(
-        !anchor_lang::solana_program::system_program::check_id(
-            ctx.accounts.middleware_account.owner
-        ),
+        ctx.accounts
+            .transaction_account
+            .whitelisted_middleware_programs
+            .contains(ctx.accounts.middleware_account.owner),
         CryptidError::InvalidMiddlewareAccount
     );
 

--- a/programs/cryptid/src/instructions/extend_transaction.rs
+++ b/programs/cryptid/src/instructions/extend_transaction.rs
@@ -54,7 +54,8 @@ pub struct ExtendTransaction<'info> {
                 transaction_account.accounts.len() + num_accounts as usize,
                 InstructionSize::from_iter_to_iter(
                     instructions.iter().chain(transaction_account.instructions.iter())
-                )
+                ),
+                transaction_account.whitelisted_middleware_programs.len()
             ),
         realloc::payer = authority,
         realloc::zero = false,

--- a/programs/cryptid/src/instructions/superuser_approve_execution.rs
+++ b/programs/cryptid/src/instructions/superuser_approve_execution.rs
@@ -25,12 +25,11 @@ pub struct SuperuserApproveExecution<'info> {
 pub fn superuser_approve_execution<'info>(
     ctx: Context<'_, '_, '_, 'info, SuperuserApproveExecution<'info>>,
 ) -> Result<()> {
-    // Make sure owner is NOT the System Program
-    // TODO(ticket): Consider implementing an approval registry on middleware
     require!(
-        !anchor_lang::solana_program::system_program::check_id(
-            ctx.accounts.middleware_account.owner
-        ),
+        ctx.accounts
+            .transaction_account
+            .whitelisted_middleware_programs
+            .contains(ctx.accounts.middleware_account.owner),
         CryptidError::InvalidMiddlewareAccount
     );
 

--- a/programs/cryptid/src/lib.rs
+++ b/programs/cryptid/src/lib.rs
@@ -68,6 +68,7 @@ pub mod cryptid {
         did_account_bump: u8,
         state: TransactionState,
         allow_unauthorized: bool,
+        whitelisted_middleware_programs: Vec<Pubkey>,
         instructions: Vec<AbbreviatedInstructionData>,
         _num_accounts: u8,
     ) -> Result<()> {
@@ -79,6 +80,7 @@ pub mod cryptid {
             did_account_bump,
             state,
             allow_unauthorized,
+            whitelisted_middleware_programs,
             instructions,
         )
     }


### PR DESCRIPTION
PERMISSIONLESS APPROVEEXECUTION INSTRUCTION ALLOWS ATTACKERS TO BLOCK ANOTHER USER'S EXECUTETRANSACTION INSTRUCTION

A permissionless instruction is when anyone on the Solana network can execute a transaction that interacts with the user’s programs. In some cases, permissionless instructions can be harmless depending on the logic of the program in question. In the case of Cryptid, the permissionless ApproveExecution instruction can have negative effects on the functionality of core operations, such as the ExecuteTransaction instruction.

This PR fixes the discovered issue.